### PR TITLE
Add yoga style props handling to group component

### DIFF
--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -127,6 +127,7 @@ ChildrenMixinStub {
               "parent": [Circular],
               "pluginData": Object {
                 "isReactFigmaNode": "true",
+                "reactStyle": "{}",
               },
               "type": "GROUP",
             },
@@ -156,6 +157,7 @@ ChildrenMixinStub {
               "parent": [Circular],
               "pluginData": Object {
                 "isReactFigmaNode": "true",
+                "reactStyle": "{}",
               },
               "type": "GROUP",
             },
@@ -163,6 +165,7 @@ ChildrenMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
+            "reactStyle": "{}",
           },
           "type": "GROUP",
         },
@@ -215,6 +218,7 @@ ChildrenMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
+            "reactStyle": "{}",
           },
           "type": "GROUP",
         },

--- a/src/renderers/group/group.ts
+++ b/src/renderers/group/group.ts
@@ -5,11 +5,24 @@ import { baseNodeMixin } from '../../mixins/baseNodeMixin';
 import { exportMixin } from '../../mixins/exportMixin';
 import { blendMixin } from '../../mixins/blendMixin';
 import { PregroupNode } from './pregroupNode';
+import { geometryMixin } from '../../mixins/geometryMixin';
 
 export const group = node => props => {
     let newNode;
-    const didMountHandler = () => {
+
+    const applyProps = () => {
         refMixin(newNode.figmaNode)(props);
+
+        saveStyleMixin(newNode.figmaNode)(props);
+        baseNodeMixin(newNode.figmaNode)(props);
+        layoutMixin(newNode.figmaNode)(props);
+        exportMixin(newNode.figmaNode)(props);
+        geometryMixin(newNode.figmaNode)(props);
+        blendMixin(newNode.figmaNode)(props);
+    };
+
+    const didMountHandler = () => {
+        applyProps();
     };
 
     if (node && node.type === 'GROUP') {
@@ -22,13 +35,7 @@ export const group = node => props => {
     }
 
     if (newNode.figmaNode) {
-        const groupNode = newNode.figmaNode;
-
-        saveStyleMixin(groupNode)(props);
-        baseNodeMixin(groupNode)(props);
-        layoutMixin(groupNode)(props);
-        exportMixin(groupNode)(props);
-        blendMixin(groupNode)(props);
+        applyProps();
     }
 
     return newNode;


### PR DESCRIPTION
To see that it's working use something like this
```javascript
<Group
    name="Button"
    style={{
        backgroundColor: '#12ff00',
        justifyContent: 'center',
        alignItems: 'center'
    }}>
    <Text characters="ButtonButtonButtonButtonButton" />
    <Text characters="Button" />
</Group>
```

Not quite sure that all style props would work as expected as a group's size is determined by its content