### PR TITLE
Implement SVG tree renderer

### DIFF
--- a/jsx-interfaces.d.ts
+++ b/jsx-interfaces.d.ts
@@ -8,6 +8,9 @@ import {ComponentProps} from "./src/components/component/Component"
 import {StarProps} from "./src/components/star/Star";
 import {VectorProps} from "./src/components/vector/Vector";
 
+type SvgCircleProps = any;
+// TODO: Type the rest of the Svg components
+
 declare global {
     namespace JSX {
         interface IntrinsicElements {
@@ -20,7 +23,28 @@ declare global {
             ellipse: EllipseProps;
             star: StarProps;
             vector: VectorProps,
-            instance: InstanceProps
+            instance: InstanceProps,
+            svg_circle: SvgCircleProps,
+            svg_ellipse: any,
+            svg_g: any,
+            svg_text: any,
+            svg_tspan: any,
+            svg_textPath: any,
+            svg_path: any,
+            svg_polygon: any,
+            svg_polyline: any,
+            svg_line: any,
+            svg_rect: any,
+            svg_use: any,
+            svg_image: any,
+            svg_symbol: any,
+            svg_defs: any,
+            svg_linearGradient: any,
+            svg_radialGradient: any,
+            svg_stop: any,
+            svg_clipPath: any,
+            svg_pattern: any,
+            svg_mask,
         }
     }
 }

--- a/src/components/svg/Circle.tsx
+++ b/src/components/svg/Circle.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgCircleProps = any;
+
+const SvgCircle: React.FC<SvgCircleProps> = (props) => (
+    <svg_circle {...props} />
+);
+
+export default SvgCircle;

--- a/src/components/svg/Circle.tsx
+++ b/src/components/svg/Circle.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgCircleProps = any;
 
-const SvgCircle: React.FC<SvgCircleProps> = (props) => (
-    <svg_circle {...props} />
-);
+const SvgCircle: React.FC<SvgCircleProps> = props => <svg_circle {...props} />;
 
 export default SvgCircle;

--- a/src/components/svg/ClipPath.tsx
+++ b/src/components/svg/ClipPath.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+// export interface SvgClipPathProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgClipPathProps = any;
+
+const SvgClipPath: React.FC<SvgClipPathProps> = ({ children, ...props }) => (
+    <svg_clipPath {...props}>{children}</svg_clipPath>
+);
+
+export default SvgClipPath;

--- a/src/components/svg/Defs.tsx
+++ b/src/components/svg/Defs.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgDefsProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgDefsProps = any;
 
-const SvgDefs: React.FC<SvgDefsProps> = ({ children, ...props }) => (
-    <svg_defs {...props}>{children}</svg_defs>
-);
+const SvgDefs: React.FC<SvgDefsProps> = ({ children, ...props }) => <svg_defs {...props}>{children}</svg_defs>;
 
 export default SvgDefs;

--- a/src/components/svg/Defs.tsx
+++ b/src/components/svg/Defs.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgDefsProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgDefsProps = any;
+
+const SvgDefs: React.FC<SvgDefsProps> = ({ children, ...props }) => (
+    <svg_defs {...props}>{children}</svg_defs>
+);
+
+export default SvgDefs;

--- a/src/components/svg/Ellipse.tsx
+++ b/src/components/svg/Ellipse.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgEllipseProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgEllipseProps = any;
+
+const SvgEllipse: React.FC<SvgEllipseProps> = ({ children, ...props }) => (
+    <svg_ellipse {...props}>{children}</svg_ellipse>
+);
+
+export default SvgEllipse;

--- a/src/components/svg/Ellipse.tsx
+++ b/src/components/svg/Ellipse.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgEllipseProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/G.tsx
+++ b/src/components/svg/G.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgGProps = any;
+
+const SvgG: React.FC<SvgGProps> = ({ children, ...props }) => (
+    <svg_g {...props}>{children}</svg_g>
+);
+
+export default SvgG;

--- a/src/components/svg/G.tsx
+++ b/src/components/svg/G.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgGProps = any;
 
-const SvgG: React.FC<SvgGProps> = ({ children, ...props }) => (
-    <svg_g {...props}>{children}</svg_g>
-);
+const SvgG: React.FC<SvgGProps> = ({ children, ...props }) => <svg_g {...props}>{children}</svg_g>;
 
 export default SvgG;

--- a/src/components/svg/Image.tsx
+++ b/src/components/svg/Image.tsx
@@ -1,23 +1,20 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgImageProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgImageProps = any;
 
-const SvgImage: React.FC<SvgImageProps> = ({ children, ...props }) => (
-    <svg_image {...props}>{children}</svg_image>
-);
+const SvgImage: React.FC<SvgImageProps> = ({ children, ...props }) => <svg_image {...props}>{children}</svg_image>;
 
 SvgImage.defaultProps = {
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 0,
-  preserveAspectRatio: 'xMidYMid meet',
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    preserveAspectRatio: 'xMidYMid meet'
 };
 
 export default SvgImage;

--- a/src/components/svg/Image.tsx
+++ b/src/components/svg/Image.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgImageProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgImageProps = any;
+
+const SvgImage: React.FC<SvgImageProps> = ({ children, ...props }) => (
+    <svg_image {...props}>{children}</svg_image>
+);
+
+SvgImage.defaultProps = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  preserveAspectRatio: 'xMidYMid meet',
+};
+
+export default SvgImage;

--- a/src/components/svg/Line.tsx
+++ b/src/components/svg/Line.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgLineProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgLineProps = any;
 
-const SvgLine: React.FC<SvgLineProps> = ({ children, ...props }) => (
-    <svg_line {...props}>{children}</svg_line>
-);
+const SvgLine: React.FC<SvgLineProps> = ({ children, ...props }) => <svg_line {...props}>{children}</svg_line>;
 
 export default SvgLine;

--- a/src/components/svg/Line.tsx
+++ b/src/components/svg/Line.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgLineProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgLineProps = any;
+
+const SvgLine: React.FC<SvgLineProps> = ({ children, ...props }) => (
+    <svg_line {...props}>{children}</svg_line>
+);
+
+export default SvgLine;

--- a/src/components/svg/LinearGradient.tsx
+++ b/src/components/svg/LinearGradient.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgLinearGradientProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/LinearGradient.tsx
+++ b/src/components/svg/LinearGradient.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgLinearGradientProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgLinearGradientProps = any;
+
+const SvgLinearGradient: React.FC<SvgLinearGradientProps> = ({ children, ...props }) => (
+    <svg_linearGradient {...props}>{children}</svg_linearGradient>
+);
+
+export default SvgLinearGradient;

--- a/src/components/svg/Mask.tsx
+++ b/src/components/svg/Mask.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgMaskProps = any;
 
-const SvgMask: React.FC<SvgMaskProps> = ({ children, ...props }) => (
-    <svg_mask {...props}>{children}</svg_mask>
-);
+const SvgMask: React.FC<SvgMaskProps> = ({ children, ...props }) => <svg_mask {...props}>{children}</svg_mask>;
 
 export default SvgMask;

--- a/src/components/svg/Mask.tsx
+++ b/src/components/svg/Mask.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgMaskProps = any;
+
+const SvgMask: React.FC<SvgMaskProps> = ({ children, ...props }) => (
+    <svg_mask {...props}>{children}</svg_mask>
+);
+
+export default SvgMask;

--- a/src/components/svg/Path.tsx
+++ b/src/components/svg/Path.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgPathProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgPathProps = any;
+
+const SvgPath: React.FC<SvgPathProps> = ({ children, ...props }) => (
+    <svg_path {...props}>{children}</svg_path>
+);
+
+export default SvgPath;

--- a/src/components/svg/Path.tsx
+++ b/src/components/svg/Path.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgPathProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgPathProps = any;
 
-const SvgPath: React.FC<SvgPathProps> = ({ children, ...props }) => (
-    <svg_path {...props}>{children}</svg_path>
-);
+const SvgPath: React.FC<SvgPathProps> = ({ children, ...props }) => <svg_path {...props}>{children}</svg_path>;
 
 export default SvgPath;

--- a/src/components/svg/Pattern.tsx
+++ b/src/components/svg/Pattern.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/Pattern.tsx
+++ b/src/components/svg/Pattern.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgCircleProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgPatternProps = any;
+
+const SvgPattern: React.FC<SvgPatternProps> = ({ children, ...props }) => (
+    <svg_pattern {...props}>{children}</svg_pattern>
+);
+
+export default SvgPattern;

--- a/src/components/svg/Polygon.tsx
+++ b/src/components/svg/Polygon.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgPolygonProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/Polygon.tsx
+++ b/src/components/svg/Polygon.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgPolygonProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgPolygonProps = any;
+
+const SvgPolygon: React.FC<SvgPolygonProps> = ({ children, ...props }) => (
+    <svg_polygon {...props}>{children}</svg_polygon>
+);
+
+export default SvgPolygon;

--- a/src/components/svg/Polyline.tsx
+++ b/src/components/svg/Polyline.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgPolylineProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/Polyline.tsx
+++ b/src/components/svg/Polyline.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgPolylineProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgPolylineProps = any;
+
+const SvgPolyline: React.FC<SvgPolylineProps> = ({ children, ...props }) => (
+    <svg_polyline {...props}>{children}</svg_polyline>
+);
+
+export default SvgPolyline;

--- a/src/components/svg/RadialGradient.tsx
+++ b/src/components/svg/RadialGradient.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgRadialGradientProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/RadialGradient.tsx
+++ b/src/components/svg/RadialGradient.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgRadialGradientProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgRadialGradientProps = any;
+
+const SvgRadialGradient: React.FC<SvgRadialGradientProps> = ({ children, ...props }) => (
+    <svg_radialGradient {...props}>{children}</svg_radialGradient>
+);
+
+export default SvgRadialGradient;

--- a/src/components/svg/Rect.tsx
+++ b/src/components/svg/Rect.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgRectProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgRectProps = any;
 
-const SvgRect: React.FC<SvgRectProps> = ({ children, ...props }) => (
-    <svg_rect {...props}>{children}</svg_rect>
-);
+const SvgRect: React.FC<SvgRectProps> = ({ children, ...props }) => <svg_rect {...props}>{children}</svg_rect>;
 
 export default SvgRect;

--- a/src/components/svg/Rect.tsx
+++ b/src/components/svg/Rect.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgRectProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgRectProps = any;
+
+const SvgRect: React.FC<SvgRectProps> = ({ children, ...props }) => (
+    <svg_rect {...props}>{children}</svg_rect>
+);
+
+export default SvgRect;

--- a/src/components/svg/Stop.tsx
+++ b/src/components/svg/Stop.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgStopProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgStopProps = any;
+
+const SvgStop: React.FC<SvgStopProps> = ({ children, ...props }) => (
+    <svg_stop {...props}>{children}</svg_stop>
+);
+
+export default SvgStop;

--- a/src/components/svg/Stop.tsx
+++ b/src/components/svg/Stop.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgStopProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgStopProps = any;
 
-const SvgStop: React.FC<SvgStopProps> = ({ children, ...props }) => (
-    <svg_stop {...props}>{children}</svg_stop>
-);
+const SvgStop: React.FC<SvgStopProps> = ({ children, ...props }) => <svg_stop {...props}>{children}</svg_stop>;
 
 export default SvgStop;

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -15,12 +15,40 @@ import { StyleSheet } from '../../helpers/StyleSheet';
 import { useSelectionChange } from '../../hooks/useSelectionChange';
 import { transformAutoLayoutToYoga } from '../../styleTransformers/transformAutoLayoutToYoga';
 
+import Circle from './Circle';
+import Ellipse from './Ellipse';
+import G from './G';
+import Text from './Text';
+import TSpan from './TSpan';
+import TextPath from './TextPath';
+import Path from './Path';
+import Polygon from './Polygon';
+import Polyline from './Polyline';
+import Line from './Line';
+import Rect from './Rect';
+import Use from './Use';
+import Image from './Image';
+import Symbol from './Symbol';
+import Defs from './Defs';
+import LinearGradient from './LinearGradient';
+import RadialGradient from './RadialGradient';
+import Stop from './Stop';
+import ClipPath from './ClipPath';
+import Pattern from './Pattern';
+import Mask from './Mask';
+
 export interface SvgNodeProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
     style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
     source?: string;
+    viewBox?: string;
 }
 
-export const Svg: React.FC<SvgNodeProps> = props => {
+
+type SvgPartTypes = 'Circle' | 'Ellipse' | 'G' | 'Text' | 'TSpan' | 'TextPath' | 'Path' | 'Polygon' | 'Polyline' | 'Line' | 'Rect' | 'Use' | 'Image' | 'Symbol' | 'Defs' | 'LinearGradient' | 'RadialGradient' | 'Stop' | 'ClipPath' | 'Pattern' | 'Mask';
+
+type SvgParts = { [P in SvgPartTypes]?: any };
+
+const Svg: React.FC<SvgNodeProps> & SvgParts = (props) => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -36,5 +64,30 @@ export const Svg: React.FC<SvgNodeProps> = props => {
     };
     const yogaChildProps = useYogaLayout({ nodeRef, ...frameProps });
 
-    return <svg {...frameProps} {...yogaChildProps} innerRef={nodeRef} />;
+    return <svg {...frameProps} {...yogaChildProps} isBuilding={!!props.children} innerRef={nodeRef} />;
 };
+
+
+Svg.Circle = Circle;
+Svg.Ellipse = Ellipse;
+Svg.G = G;
+Svg.Text = Text;
+Svg.TSpan = TSpan;
+Svg.TextPath = TextPath;
+Svg.Path = Path;
+Svg.Polygon = Polygon;
+Svg.Polyline = Polyline;
+Svg.Line = Line;
+Svg.Rect = Rect;
+Svg.Use = Use;
+Svg.Image = Image;
+Svg.Symbol = Symbol;
+Svg.Defs = Defs;
+Svg.LinearGradient = LinearGradient;
+Svg.RadialGradient = RadialGradient;
+Svg.Stop = Stop;
+Svg.ClipPath = ClipPath;
+Svg.Pattern = Pattern;
+Svg.Mask = Mask;
+
+export default Svg;

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -43,12 +43,32 @@ export interface SvgNodeProps extends DefaultContainerProps, InstanceItemProps, 
     viewBox?: string;
 }
 
-
-type SvgPartTypes = 'Circle' | 'Ellipse' | 'G' | 'Text' | 'TSpan' | 'TextPath' | 'Path' | 'Polygon' | 'Polyline' | 'Line' | 'Rect' | 'Use' | 'Image' | 'Symbol' | 'Defs' | 'LinearGradient' | 'RadialGradient' | 'Stop' | 'ClipPath' | 'Pattern' | 'Mask';
+type SvgPartTypes =
+    | 'Circle'
+    | 'Ellipse'
+    | 'G'
+    | 'Text'
+    | 'TSpan'
+    | 'TextPath'
+    | 'Path'
+    | 'Polygon'
+    | 'Polyline'
+    | 'Line'
+    | 'Rect'
+    | 'Use'
+    | 'Image'
+    | 'Symbol'
+    | 'Defs'
+    | 'LinearGradient'
+    | 'RadialGradient'
+    | 'Stop'
+    | 'ClipPath'
+    | 'Pattern'
+    | 'Mask';
 
 type SvgParts = { [P in SvgPartTypes]?: any };
 
-const Svg: React.FC<SvgNodeProps> & SvgParts = (props) => {
+const Svg: React.FC<SvgNodeProps> & SvgParts = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -66,7 +86,6 @@ const Svg: React.FC<SvgNodeProps> & SvgParts = (props) => {
 
     return <svg {...frameProps} {...yogaChildProps} isBuilding={!!props.children} innerRef={nodeRef} />;
 };
-
 
 Svg.Circle = Circle;
 Svg.Ellipse = Ellipse;

--- a/src/components/svg/Symbol.tsx
+++ b/src/components/svg/Symbol.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgSymbolProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgSymbolProps = any;
+
+const SvgSymbol: React.FC<SvgSymbolProps> = ({ children, ...props }) => (
+    <svg_symbol {...props}>{children}</svg_symbol>
+);
+
+export default SvgSymbol;

--- a/src/components/svg/Symbol.tsx
+++ b/src/components/svg/Symbol.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgSymbolProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgSymbolProps = any;
 
-const SvgSymbol: React.FC<SvgSymbolProps> = ({ children, ...props }) => (
-    <svg_symbol {...props}>{children}</svg_symbol>
-);
+const SvgSymbol: React.FC<SvgSymbolProps> = ({ children, ...props }) => <svg_symbol {...props}>{children}</svg_symbol>;
 
 export default SvgSymbol;

--- a/src/components/svg/TSpan.tsx
+++ b/src/components/svg/TSpan.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgTSpanProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgTSpanProps = any;
+
+const SvgTSpan: React.FC<SvgTSpanProps> = ({ children, ...props }) => (
+    <svg_tspan {...props}>{children}</svg_tspan>
+);
+
+export default SvgTSpan;

--- a/src/components/svg/TSpan.tsx
+++ b/src/components/svg/TSpan.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgTSpanProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgTSpanProps = any;
 
-const SvgTSpan: React.FC<SvgTSpanProps> = ({ children, ...props }) => (
-    <svg_tspan {...props}>{children}</svg_tspan>
-);
+const SvgTSpan: React.FC<SvgTSpanProps> = ({ children, ...props }) => <svg_tspan {...props}>{children}</svg_tspan>;
 
 export default SvgTSpan;

--- a/src/components/svg/Text.tsx
+++ b/src/components/svg/Text.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgTextProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgTextProps = any;
+
+const SvgText: React.FC<SvgTextProps> = ({ children, ...props }) => (
+    <svg_text {...props}>{children}</svg_text>
+);
+
+export default SvgText;

--- a/src/components/svg/Text.tsx
+++ b/src/components/svg/Text.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgTextProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgTextProps = any;
 
-const SvgText: React.FC<SvgTextProps> = ({ children, ...props }) => (
-    <svg_text {...props}>{children}</svg_text>
-);
+const SvgText: React.FC<SvgTextProps> = ({ children, ...props }) => <svg_text {...props}>{children}</svg_text>;
 
 export default SvgText;

--- a/src/components/svg/TextPath.tsx
+++ b/src/components/svg/TextPath.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgTextPathProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;

--- a/src/components/svg/TextPath.tsx
+++ b/src/components/svg/TextPath.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgTextPathProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgTextPathProps = any;
+
+const SvgTextPath: React.FC<SvgTextPathProps> = ({ children, ...props }) => (
+    <svg_textPath {...props}>{children}</svg_textPath>
+);
+
+export default SvgTextPath;

--- a/src/components/svg/Use.tsx
+++ b/src/components/svg/Use.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
 
-
 // export interface SvgUseProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
 //   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 //   source?: string;
 // }
 export type SvgUseProps = any;
 
-const SvgUse: React.FC<SvgUseProps> = ({ children, ...props }) => (
-    <svg_use {...props}>{children}</svg_use>
-);
+const SvgUse: React.FC<SvgUseProps> = ({ children, ...props }) => <svg_use {...props}>{children}</svg_use>;
 
 export default SvgUse;

--- a/src/components/svg/Use.tsx
+++ b/src/components/svg/Use.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CornerProps, DefaultContainerProps, InstanceItemProps, SelectionEventProps, StyleOf } from '../../types';
+
+
+// export interface SvgUseProps extends DefaultContainerProps, InstanceItemProps, SelectionEventProps {
+//   style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
+//   source?: string;
+// }
+export type SvgUseProps = any;
+
+const SvgUse: React.FC<SvgUseProps> = ({ children, ...props }) => (
+    <svg_use {...props}>{children}</svg_use>
+);
+
+export default SvgUse;

--- a/src/components/svg/index.ts
+++ b/src/components/svg/index.ts
@@ -23,27 +23,27 @@ import Mask from './Mask';
 import Svg from './Svg';
 
 export {
-  Circle,
-  Ellipse,
-  G,
-  Text,
-  TSpan,
-  TextPath,
-  Path,
-  Polygon,
-  Polyline,
-  Line,
-  Rect,
-  Use,
-  Image,
-  Symbol,
-  Defs,
-  LinearGradient,
-  RadialGradient,
-  Stop,
-  ClipPath,
-  Pattern,
-  Mask
+    Circle,
+    Ellipse,
+    G,
+    Text,
+    TSpan,
+    TextPath,
+    Path,
+    Polygon,
+    Polyline,
+    Line,
+    Rect,
+    Use,
+    Image,
+    Symbol,
+    Defs,
+    LinearGradient,
+    RadialGradient,
+    Stop,
+    ClipPath,
+    Pattern,
+    Mask
 };
 
 export default Svg;

--- a/src/components/svg/index.ts
+++ b/src/components/svg/index.ts
@@ -1,0 +1,49 @@
+import Circle from './Circle';
+import Ellipse from './Ellipse';
+import G from './G';
+import Text from './Text';
+import TSpan from './TSpan';
+import TextPath from './TextPath';
+import Path from './Path';
+import Polygon from './Polygon';
+import Polyline from './Polyline';
+import Line from './Line';
+import Rect from './Rect';
+import Use from './Use';
+import Image from './Image';
+import Symbol from './Symbol';
+import Defs from './Defs';
+import LinearGradient from './LinearGradient';
+import RadialGradient from './RadialGradient';
+import Stop from './Stop';
+import ClipPath from './ClipPath';
+import Pattern from './Pattern';
+import Mask from './Mask';
+
+import Svg from './Svg';
+
+export {
+  Circle,
+  Ellipse,
+  G,
+  Text,
+  TSpan,
+  TextPath,
+  Path,
+  Polygon,
+  Polyline,
+  Line,
+  Rect,
+  Use,
+  Image,
+  Symbol,
+  Defs,
+  LinearGradient,
+  RadialGradient,
+  Stop,
+  ClipPath,
+  Pattern,
+  Mask
+};
+
+export default Svg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { Vector } from './components/vector/Vector';
 export { Line } from './components/line/Line';
 export { Ellipse } from './components/ellipse/Ellipse';
 export { View } from './components/view/View';
-export { Svg } from './components/svg/Svg';
+export { default as Svg } from './components/svg/';
 export { Image } from './components/Image/Image';
 
 export { StyleSheet } from './helpers/StyleSheet';

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -34,6 +34,13 @@ const appendToContainer = (parentNode, childNode) => {
         if (parentNode.type === 'TEXT') {
             setTextInstance(parentNode, childNode);
         }
+    } else if (childNode.type.includes('SVG_') && childNode.type !== 'SVG_SVG') {
+        if (parentNode.type.includes('SVG_') && Array.isArray(parentNode.children)) {
+            parentNode.children.push(childNode);
+        }
+    } else if (childNode.type === 'SVG_SVG') {
+        const built = childNode.build(childNode);
+        parentNode.appendChild(built);
     } else {
         parentNode.appendChild(childNode);
     }
@@ -64,7 +71,7 @@ const remove = childNode => {
 
 const renderInstance = (type, node, props) => {
     const instance = renderers[type](node)(props);
-    if (!node) {
+    if (!node && instance.setPluginData) {
         instance.setPluginData('isReactFigmaNode', 'true');
     }
     if (type === 'page' && props.isCurrent) {

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -10,3 +10,51 @@ export { line } from './line';
 export { group } from './group';
 export { ellipse } from './ellipse';
 export { svg } from './svg';
+
+import svgElement from './svg-element';
+
+const svg_circle = svgElement('circle');
+const svg_ellipse = svgElement('ellipse');
+const svg_g = svgElement('g');
+const svg_text = svgElement('text');
+const svg_tspan = svgElement('tspan');
+const svg_textPath = svgElement('textPath');
+const svg_path = svgElement('path');
+const svg_polygon = svgElement('polygon');
+const svg_polyline = svgElement('polyline');
+const svg_line = svgElement('line');
+const svg_rect = svgElement('rect');
+const svg_use = svgElement('use');
+const svg_image = svgElement('image');
+const svg_symbol = svgElement('symbol');
+const svg_defs = svgElement('defs');
+const svg_linearGradient = svgElement('linearGradient');
+const svg_radialGradient = svgElement('radialGradient');
+const svg_stop = svgElement('stop');
+const svg_clipPath = svgElement('clipPath');
+const svg_pattern = svgElement('pattern');
+const svg_mask = svgElement('mask');
+
+export {
+    svg_circle,
+    svg_ellipse,
+    svg_g,
+    svg_text,
+    svg_tspan,
+    svg_textPath,
+    svg_path,
+    svg_polygon,
+    svg_polyline,
+    svg_line,
+    svg_rect,
+    svg_use,
+    svg_image,
+    svg_symbol,
+    svg_defs,
+    svg_linearGradient,
+    svg_radialGradient,
+    svg_stop,
+    svg_clipPath,
+    svg_pattern,
+    svg_mask
+};

--- a/src/renderers/svg-element.ts
+++ b/src/renderers/svg-element.ts
@@ -1,0 +1,3 @@
+export default part => node => props => {
+  return node || { type: `SVG_${part.toUpperCase()}`, children: [], props };
+};

--- a/src/renderers/svg.ts
+++ b/src/renderers/svg.ts
@@ -14,19 +14,106 @@ const createNodeFromSvg = source => {
     return node;
 };
 
-export const svg = node => (props: SvgNodeProps) => {
-    let frameNode = node || props.node || createNodeFromSvg(props.source);
+const snakeExceptions = [
+    'gradientUnits',
+    'gradientTransform',
+    'patternUnits',
+    'patternTransform',
+    'stdDeviation',
+    'numOctaves',
+    'specularExponent',
+    'specularConstant',
+    'surfaceScale',
+    'viewBox'
+];
+function toSnakeCase(string: string) {
+    if (string === 'href') {
+        return 'xlink:href';
+    }
+    if (snakeExceptions.indexOf(string) !== -1) {
+        return string;
+    }
+    return string.replace(/([A-Z])/g, $1 => `-${$1.toLowerCase()}`);
+}
+
+const caseMappings = {
+    SVG_TEXTPATH: 'textPath',
+    SVG_LINEARGRADIENT: 'linearGradient',
+    SVG_RADIALGRADIENT: 'radialGradient',
+    SVG_CLIPPATH: 'clipPath'
+};
+
+// Function adapted from https://github.com/airbnb/react-sketchapp/blob/5a66a14a53875324bc39bde87597fe35e3b254ff/src/renderers/SvgRenderer.ts
+function makeSvgString(el: string | { type: string; props: any; children: any }) {
+    if (typeof el === 'string') {
+        return el;
+    }
+    const { type, props: { children: propsChildren, ...props } = {} } = el;
+
+    let children = el.children || propsChildren;
+    if (children && !Array.isArray(children)) {
+        children = [children];
+    }
+
+    if (!type || !type.toLowerCase().includes('svg_')) {
+        throw new Error(`Could not render type '${type}'. Make sure to only have <Svg.*> components inside <Svg>.`);
+    }
+
+    const cleanedType = caseMappings[type] || type.slice(4).toLowerCase();
+    const attributes = Object.keys(props || {}).reduce(
+        // @ts-ignore
+        (prev, k) => (props[k] ? `${prev} ${toSnakeCase(k)}="${props[k]}"` : prev),
+        ''
+    );
+
+    let string = `<${cleanedType}${attributes}`;
+
+    if (!children || !children.length) {
+        string += '/>\n';
+    } else {
+        string += '>\n';
+        string += (children || []).reduce((prev, c) => `${prev}  ${makeSvgString(c)}`, '');
+        string += `</${cleanedType}>\n`;
+    }
+
+    return string;
+}
+
+export const svg = node => (
+    props: SvgNodeProps & { isBuilding: boolean; children?: { type: string; props: any; children: any } }
+) => {
+    if (props.isBuilding) {
+        return (
+            node || {
+                type: 'SVG_SVG',
+                props,
+                children: [],
+                build: children => {
+                    return svg(node)({ ...props, children, isBuilding: false });
+                }
+            }
+        );
+    }
+
+    let source = props.source; // Default to SvgXml string behaviour
+
+    if (!source && props.children) {
+        // Use Svg.* children if found
+        source = makeSvgString(props.children);
+    }
+
+    let frameNode = node || props.node || createNodeFromSvg(source);
 
     const savedHash = frameNode.getPluginData('svgHash');
-    if (savedHash != hashCode(props.source)) {
-        const newSvg = figma.createNodeFromSvg(props.source);
+    if (savedHash != hashCode(source)) {
+        const newSvg = figma.createNodeFromSvg(source);
         layoutMixin(newSvg)(props);
         frameNode.children.forEach(child => child.remove());
         newSvg.children.forEach(child => {
             frameNode.appendChild(child);
         });
         newSvg.remove();
-        node.setPluginData('svgHash', hashCode(props.source));
+        node.setPluginData('svgHash', hashCode(source));
     }
 
     refMixin(frameNode)(props);


### PR DESCRIPTION
fixes #154 

Ended up carrying on the effort from #182 and working inside `react-reconciler` , my idea of rendering the markup to a string was a bad idea 😄.

Some of the typing was skipped and needs to be done still.

I need to create an svg example too.

## Demo

![image](https://user-images.githubusercontent.com/6757532/78515953-b05ba680-77af-11ea-9489-4d840c293550.png)
