### PR TITLE
Fix render of expressions as text

### DIFF
--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -814,6 +814,81 @@ ChildrenMixinStub {
 }
 `;
 
+exports[`renderer Text with expression 1`] = `
+ChildrenMixinStub {
+  "children": Array [
+    ExportMixinStub {
+      "children": Array [],
+      "id": "0:1",
+      "parent": [Circular],
+      "type": "PAGE",
+    },
+    ExportMixinStub {
+      "children": Array [
+        ExportMixinStub {
+          "_characters": "1/2",
+          "_textAutoResize": "WIDTH_AND_HEIGHT",
+          "autoRename": false,
+          "blendMode": "NORMAL",
+          "effects": Array [],
+          "exportSettings": Array [],
+          "fills": Array [
+            Object {
+              "color": Object {
+                "b": 0,
+                "g": 0,
+                "r": 0,
+              },
+              "opacity": 1,
+              "type": "SOLID",
+            },
+          ],
+          "fontSize": 12,
+          "id": "1:2",
+          "isMask": false,
+          "letterSpacing": Object {
+            "unit": "PIXELS",
+            "value": 0,
+          },
+          "lineHeight": Object {
+            "unit": "AUTO",
+          },
+          "locked": false,
+          "opacity": 1,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "parent": [Circular],
+          "pluginData": Object {
+            "isReactFigmaNode": "true",
+            "reactStyle": "{}",
+          },
+          "strokeAlign": "INSIDE",
+          "strokeCap": "NONE",
+          "strokeWeight": 0,
+          "strokes": Array [],
+          "textAlignHorizontal": "LEFT",
+          "textAlignVertical": "TOP",
+          "textCase": "ORIGINAL",
+          "textDecoration": "NONE",
+          "type": "TEXT",
+          "visible": true,
+        },
+      ],
+      "exportSettings": Array [],
+      "id": "1:1",
+      "parent": [Circular],
+      "pluginData": Object {
+        "isReactFigmaNode": "true",
+        "reactStyle": "{}",
+      },
+      "type": "PAGE",
+    },
+  ],
+  "id": "0:0",
+  "type": "DOCUMENT",
+}
+`;
+
 exports[`renderer createComponent basic 1`] = `
 ChildrenMixinStub {
   "children": Array [

--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -295,6 +295,22 @@ describe('renderer', () => {
         expect(removeMeta(figma.root)).toMatchSnapshot();
     });
 
+    it('Text with expression', async () => {
+        const a = 1;
+        const b = 2;
+        await render(
+            <Page>
+                <Text>
+                    {a}/{b}
+                </Text>
+            </Page>
+        );
+
+        await wait();
+        expect(removeMeta(figma.root.children[1].children[0]['_characters'])).toBe('1/2');
+        expect(removeMeta(figma.root)).toMatchSnapshot();
+    });
+
     it('Text instance updating', async () => {
         const waiting = new Subject();
         figma.createText = jest.fn().mockImplementation(figma.createText);

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -26,10 +26,14 @@ import { transformAutoLayoutToYoga } from '../../styleTransformers/transformAuto
 
 export interface TextProps extends TextNodeProps, DefaultShapeProps, InstanceItemProps, SelectionEventProps {
     style?: StyleOf<YogaStyleProperties & LayoutStyleProperties & TextStyleProperties & BlendStyleProperties> | void;
-    children?: string;
+    children?: React.ReactText | React.ReactText[];
     node?: any;
     preventResizing?: boolean;
 }
+
+const normalizeTextNodeChidren = children => {
+    return Array.isArray(children) ? children.join('') : children;
+};
 
 export const Text: React.FC<TextProps> = props => {
     const nodeRef = React.useRef();
@@ -37,6 +41,7 @@ export const Text: React.FC<TextProps> = props => {
     useSelectionChange(nodeRef, props);
 
     const style = { ...StyleSheet.flatten(props.style), ...transformAutoLayoutToYoga(props) };
+    const children = normalizeTextNodeChidren(props.children);
 
     const charactersByChildren = useTextChildren(nodeRef);
 
@@ -46,7 +51,8 @@ export const Text: React.FC<TextProps> = props => {
         ...transformBlendProperties(style),
         ...props,
         characters: charactersByChildren || props.characters,
-        style
+        style,
+        children
     };
     const hasDefinedWidth = textProps.width || style.maxWidth;
     const loadedFont = useFontName(textProps.fontName || { family: 'Roboto', style: 'Regular' });


### PR DESCRIPTION
## Overview

When text nodes are written as expressions in JSX they return as an array of text nodes, which was mapping to the Observable as three separate text updates, where only the text node in the last array index rendered.

I added a function `normalizeTextNodeChidren` which joins text nodes if they're an array. 

**Note:** First commit on this project, so let me know if I overlooked any conventions. 

Fixes: #311

### Changes
 
- Add typedef for TextProps.children
- Add function to normalize text when input as array
- Add test

Thanks!