### PR TITLE
Add React DevTools support

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -1,0 +1,22 @@
+---
+id: devtools
+title: React DevTools
+---
+
+With react-figma it is possible to use [React DevTools](https://github.com/facebook/react/tree/master/packages/react-devtools) electron app.
+
+1. If you don't have React DevTools app installed follow steps from [Installation](https://github.com/facebook/react/tree/master/packages/react-devtools#installation) section
+
+2. In your `src/ui.tsx` import `connectToDevTools` helper:
+
+```ts
+import { render, connectToDevTools } from 'react-figma';
+```
+
+3. Call `connectToDevTools` function right before your `render` function:
+
+```tsx
+connectToDevTools();
+
+render(<App />);
+```

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.18.2",
     "react": "16.8.6",
+    "react-devtools-core": "^4.7.0",
     "react-figma-webpack-config": "0.0.7",
     "react-test-renderer": "16.8.6",
     "rimraf": "^3.0.0",

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -8,7 +8,7 @@ export interface ImageProps extends RectangleProps {
     resizeMode?: ResizeMode;
 }
 
-export const Image: React.FC<ImageProps> = props => {
+const Image: React.FC<ImageProps> = props => {
     const { style, source, resizeMode } = props;
     return (
         <Rectangle
@@ -17,3 +17,5 @@ export const Image: React.FC<ImageProps> = props => {
         />
     );
 };
+
+export { Image };

--- a/src/components/component/Component.tsx
+++ b/src/components/component/Component.tsx
@@ -16,7 +16,7 @@ export interface ComponentProps extends DefaultContainerProps, SelectionEventPro
     nodeRef?: any;
 }
 
-export const Component: React.FC<ComponentProps> = props => {
+const Component: React.FC<ComponentProps> = props => {
     const nodeRef = props.nodeRef || React.useRef();
     useSelectionChange(nodeRef, props);
     const style = { ...StyleSheet.flatten(props.style), ...transformAutoLayoutToYoga(props) };
@@ -30,3 +30,5 @@ export const Component: React.FC<ComponentProps> = props => {
 
     return <component {...componentProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
+
+export { Component };

--- a/src/components/component/Instance.tsx
+++ b/src/components/component/Instance.tsx
@@ -46,7 +46,7 @@ const Override = props => {
     }
 };
 
-export const Instance: React.FC<InstanceProps> = props => {
+const Instance: React.FC<InstanceProps> = props => {
     const [isHaveNode, setHaveNode] = React.useState(false);
     const nodeRef = React.useRef<InstanceNode>();
     useSelectionChange(nodeRef, props);
@@ -75,3 +75,5 @@ export const Instance: React.FC<InstanceProps> = props => {
         </instance>
     );
 };
+
+export { Instance };

--- a/src/components/ellipse/Ellipse.tsx
+++ b/src/components/ellipse/Ellipse.tsx
@@ -22,7 +22,7 @@ export interface EllipseProps extends DefaultShapeProps, CornerProps, InstanceIt
     arcData?: ArcData;
 }
 
-export const Ellipse: React.FC<EllipseProps> = props => {
+const Ellipse: React.FC<EllipseProps> = props => {
     const nodeRef = React.useRef();
     useSelectionChange(nodeRef, props);
     const style = { ...StyleSheet.flatten(props.style), ...transformAutoLayoutToYoga(props) };
@@ -38,3 +38,5 @@ export const Ellipse: React.FC<EllipseProps> = props => {
     const yogaChildProps = useYogaLayout({ nodeRef, ...ellipseProps });
     return <ellipse {...ellipseProps} {...yogaChildProps} {...(fills && { fills })} innerRef={nodeRef} />;
 };
+
+export { Ellipse };

--- a/src/components/frame/Frame.tsx
+++ b/src/components/frame/Frame.tsx
@@ -222,7 +222,7 @@ export interface FrameNodeProps
     preset?: Preset;
 }
 
-export const Frame: React.FC<FrameNodeProps> = props => {
+const Frame: React.FC<FrameNodeProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -243,3 +243,5 @@ export const Frame: React.FC<FrameNodeProps> = props => {
 
     return <frame {...frameProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
+
+export { Frame };

--- a/src/components/group/Group.tsx
+++ b/src/components/group/Group.tsx
@@ -19,7 +19,7 @@ export interface GroupNodeProps extends DefaultShapeProps, InstanceItemProps, Se
     style?: StyleOf<GeometryStyleProperties & YogaStyleProperties & LayoutStyleProperties & BlendStyleProperties>;
 }
 
-export const Group: React.FC<GroupNodeProps> = props => {
+const Group: React.FC<GroupNodeProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -37,3 +37,5 @@ export const Group: React.FC<GroupNodeProps> = props => {
 
     return <group {...groupProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
+
+export { Group };

--- a/src/components/line/Line.tsx
+++ b/src/components/line/Line.tsx
@@ -26,7 +26,7 @@ export interface LineProps extends DefaultShapeProps, CornerProps, BorderProps, 
     style?: StyleOf<YogaStyleProperties & LayoutStyleProperties & GeometryStyleProperties & BlendStyleProperties>;
 }
 
-export const Line: React.FC<LineProps> = props => {
+const Line: React.FC<LineProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -45,3 +45,5 @@ export const Line: React.FC<LineProps> = props => {
 
     return <line {...lineProps} {...yogaProps} innerRef={nodeRef} />;
 };
+
+export { Line };

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -32,7 +32,7 @@ export const useCurrentPageChange = (
     }, [_isCurrent]);
 };
 
-export const Page: React.FC<PageProps> = props => {
+const Page: React.FC<PageProps> = props => {
     const nodeRef = React.useRef();
     const { onCurrentChange, ...otherProps } = props;
     useCurrentPageChange(nodeRef, onCurrentChange, props.isCurrent);
@@ -40,3 +40,5 @@ export const Page: React.FC<PageProps> = props => {
     const yogaChildProps = useYogaLayout({ nodeRef, ...otherProps });
     return <page {...otherProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
+
+export { Page };

--- a/src/components/rectangle/Rectangle.tsx
+++ b/src/components/rectangle/Rectangle.tsx
@@ -43,7 +43,7 @@ export interface RectangleProps
     children?: undefined;
 }
 
-export const Rectangle: React.FC<RectangleProps> = props => {
+const Rectangle: React.FC<RectangleProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -63,3 +63,5 @@ export const Rectangle: React.FC<RectangleProps> = props => {
 
     return <rectangle {...rectangleProps} {...yogaProps} {...(fills && { fills })} innerRef={nodeRef} />;
 };
+
+export { Rectangle };

--- a/src/components/star/Star.tsx
+++ b/src/components/star/Star.tsx
@@ -33,7 +33,7 @@ export interface StarProps
     children?: undefined;
 }
 
-export const Star: React.FC<StarProps> = props => {
+const Star: React.FC<StarProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -52,3 +52,5 @@ export const Star: React.FC<StarProps> = props => {
 
     return <star {...starProps} {...yogaProps} {...(fills && { fills })} innerRef={nodeRef} />;
 };
+
+export { Star };

--- a/src/components/svg/Svg.tsx
+++ b/src/components/svg/Svg.tsx
@@ -20,7 +20,7 @@ export interface SvgNodeProps extends DefaultContainerProps, InstanceItemProps, 
     source?: string;
 }
 
-export const Svg: React.FC<SvgNodeProps> = props => {
+const Svg: React.FC<SvgNodeProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -38,3 +38,5 @@ export const Svg: React.FC<SvgNodeProps> = props => {
 
     return <svg {...frameProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
+
+export { Svg };

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -35,7 +35,7 @@ const normalizeTextNodeChidren = children => {
     return Array.isArray(children) ? children.join('') : children;
 };
 
-export const Text: React.FC<TextProps> = props => {
+const Text: React.FC<TextProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -68,3 +68,5 @@ export const Text: React.FC<TextProps> = props => {
         />
     );
 };
+
+export { Text };

--- a/src/components/vector/Vector.tsx
+++ b/src/components/vector/Vector.tsx
@@ -33,7 +33,7 @@ export interface VectorProps
     children?: undefined;
 }
 
-export const Vector: React.FC<VectorProps> = props => {
+const Vector: React.FC<VectorProps> = props => {
     const nodeRef = React.useRef();
 
     useSelectionChange(nodeRef, props);
@@ -51,3 +51,5 @@ export const Vector: React.FC<VectorProps> = props => {
     const yogaProps = useYogaLayout({ nodeRef, ...vectorProps });
     return <vector {...vectorProps} {...yogaProps} {...(fills && { fills })} innerRef={nodeRef} />;
 };
+
+export { Vector };

--- a/src/components/view/View.tsx
+++ b/src/components/view/View.tsx
@@ -5,7 +5,7 @@ import { FrameNodeProps } from '../frame/Frame';
 
 export type ViewProps = FrameNodeProps | RectangleProps;
 
-export const View: React.FC<ViewProps> = props => {
+const View: React.FC<ViewProps> = props => {
     if (props.children) {
         return (
             <Frame
@@ -17,3 +17,5 @@ export const View: React.FC<ViewProps> = props => {
         return <Rectangle {...(props as RectangleProps)} />;
     }
 };
+
+export { View };

--- a/src/helpers/connectToDevTools.ts
+++ b/src/helpers/connectToDevTools.ts
@@ -1,13 +1,18 @@
 import { connectToDevTools as connectToDevToolsInternal } from 'react-devtools-core';
 
 export const connectToDevTools = () => {
-    // Try construction is used to avoid crashing if devtools is not launched
-    try {
-        connectToDevToolsInternal({
-            isAppActive: () => true,
-            host: 'localhost',
-            port: 8097,
-            resolveRNStyle: null
-        });
-    } catch (e) {}
+    let connectionFailed = false;
+    const connection = new WebSocket('ws://localhost:8097');
+
+    connectToDevToolsInternal({
+        // prevents from multiple retries
+        isAppActive: () => !connectionFailed,
+        resolveRNStyle: null,
+        websocket: connection
+    });
+
+    connection.onerror = () => {
+        console.warn('React DevTools is not running. Please run React DevTools or remove `connectToDevTools` call');
+        connectionFailed = true;
+    };
 };

--- a/src/helpers/connectToDevTools.ts
+++ b/src/helpers/connectToDevTools.ts
@@ -1,4 +1,5 @@
 import { connectToDevTools as connectToDevToolsInternal } from 'react-devtools-core';
+import { api } from '../rpc';
 
 export const connectToDevTools = () => {
     let connectionFailed = false;
@@ -15,4 +16,22 @@ export const connectToDevTools = () => {
         console.warn('React DevTools is not running. Please run React DevTools or remove `connectToDevTools` call');
         connectionFailed = true;
     };
+
+    // @ts-ignore
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__.on('react-devtools', agent => {
+        agent._bridge.addListener('inspectElement', data => {
+            const { rendererID, id } = data;
+
+            const renderer = agent.rendererInterfaces[rendererID];
+
+            let nodes = null;
+            if (renderer !== null) {
+                nodes = renderer.findNativeNodesForFiberID(id);
+            }
+
+            if (nodes !== null && nodes[0]) {
+                api.highlightNativeElement(nodes[0].id);
+            }
+        });
+    });
 };

--- a/src/helpers/connectToDevTools.ts
+++ b/src/helpers/connectToDevTools.ts
@@ -1,0 +1,13 @@
+import { connectToDevTools as connectToDevToolsInternal } from 'react-devtools-core';
+
+export const connectToDevTools = () => {
+    // Try construction is used to avoid crashing if devtools is not launched
+    try {
+        connectToDevToolsInternal({
+            isAppActive: () => true,
+            host: 'localhost',
+            port: 8097,
+            resolveRNStyle: null
+        });
+    } catch (e) {}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { render } from './renderer';
+export { connectToDevTools } from './helpers/connectToDevTools';
 
 export { Text } from './components/text/Text';
 export { Rectangle } from './components/rectangle/Rectangle';

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -174,6 +174,12 @@ export const render = async (jsx: any) => {
 
     const reconciler = createReconciler(HostConfig);
 
+    reconciler.injectIntoDevTools({
+        bundleType: 1, // 0 for PROD, 1 for DEV
+        version: '0.1.4',
+        rendererPackageName: 'react-figma'
+    });
+
     const container = reconciler.createContainer(rootNode, true, true);
     reconciler.updateContainer(jsx, container);
 };

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,7 +1,6 @@
 import * as nanoid from 'nanoid/non-secure';
 
-// * Development version of react-reconciler can't be used inside Figma realm.
-import * as createReconciler from 'react-reconciler/cjs/react-reconciler.production.min';
+import * as createReconciler from 'react-reconciler';
 
 import { setTextChildren } from './hooks/useTextChildren';
 import { api } from './rpc';

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -180,7 +180,7 @@ export const api = createPluginAPI(
                 return;
             }
 
-            if(figma.currentPage.selection.includes(node)){
+            if (figma.currentPage.selection.includes(node)) {
                 return;
             }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -171,6 +171,21 @@ export const api = createPluginAPI(
         setCurrentPage(_node) {
             const node = transformToNode(_node);
             figma.currentPage = node;
+        },
+
+        highlightNativeElement(id: string) {
+            const node = figma.getNodeById(id);
+
+            if (!node || node.type === 'DOCUMENT') {
+                return;
+            }
+
+            figma.currentPage = findRoot(node);
+
+            if (node.type !== 'PAGE') {
+                figma.viewport.scrollAndZoomIntoView([node]);
+                figma.currentPage.selection = [node];
+            }
         }
     },
     {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -180,7 +180,15 @@ export const api = createPluginAPI(
                 return;
             }
 
-            figma.currentPage = findRoot(node);
+            if(figma.currentPage.selection.includes(node)){
+                return;
+            }
+
+            const nodePage = findRoot(node);
+
+            if (figma.currentPage !== nodePage) {
+                figma.currentPage = nodePage;
+            }
 
             if (node.type !== 'PAGE') {
                 figma.viewport.scrollAndZoomIntoView([node]);

--- a/website/blog/2020-07-05-devtools-support.md
+++ b/website/blog/2020-07-05-devtools-support.md
@@ -9,4 +9,4 @@ authorURL: http://twitter.com/losyear
 React Figma gains support of [React DevTools](https://github.com/facebook/react/tree/master/packages/react-devtools) electron app.
 Now developer experience has become even better.
 
-See our docs for [a guide](docs/devtools.md).
+See our docs for [a guide](docs/devtools).

--- a/website/blog/2020-07-05-devtools-support.md
+++ b/website/blog/2020-07-05-devtools-support.md
@@ -1,0 +1,12 @@
+---
+title: React DevTools support
+author: Yaroslav Losev
+authorURL: http://twitter.com/losyear
+---
+
+<p align="center"><img src="https://media.giphy.com/media/fSYEFDJ4b1Z3cDYXqK/giphy.gif" width="480" /></p>
+
+React Figma gains support of [React DevTools](https://github.com/facebook/react/tree/master/packages/react-devtools) electron app.
+Now developer experience has become even better.
+
+See our docs for [a guide](docs/devtools.md).

--- a/website/blog/2020-07-05-devtools-support.md
+++ b/website/blog/2020-07-05-devtools-support.md
@@ -9,4 +9,4 @@ authorURL: http://twitter.com/losyear
 React Figma gains support of [React DevTools](https://github.com/facebook/react/tree/master/packages/react-devtools) electron app.
 Now developer experience has become even better.
 
-See our docs for [a guide](docs/devtools).
+See our docs for [a guide](/docs/devtools).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Getting Started": ["installation", "configure", "running", "hmr"],
+    "Getting Started": ["installation", "configure", "running", "hmr", "devtools"],
     "Docs": ["API","architecture", "roadmap"],
     "API": [
       "api/render",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,6 +4297,14 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-devtools-core@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.7.0.tgz#71e89087352abe60c160dfb60a7fa700f612af7a"
+  integrity sha512-6w/e0nkV0gogUnfz+9Q3yiMtYYol9T+oD27UIf4XWmula1KvSTTkQ9DnzLOqSSch8d1YzNWbTxguuNJMof58ww==
+  dependencies:
+    shell-quote "^1.6.1"
+    ws "^7"
+
 react-fetch-hook@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/react-fetch-hook/-/react-fetch-hook-1.7.2.tgz#5aaddea774746f8e19fc3157248575d140d92108"
@@ -4742,6 +4750,11 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shell-quote@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -5699,6 +5712,11 @@ ws@^5.2.0:
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- [x] Fix node shaking after highlighting
- [x] Profiler support

Closes to #94 

Implements ability to inspect application components tree.

<img width="500" alt="Screenshot 2020-06-25 at 16 41 55" src="https://user-images.githubusercontent.com/1065122/85731070-ddf72280-b702-11ea-99cd-c85158cccd95.png">

For now it only allows to browse components tree, but not to highlight selected nodes. 
@ilyalesik can we somehow manipulate Figma's selection from API or is it read-only? Maybe you have any ideas about it?