### PR TITLE
Support rendering into target node

### DIFF
--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -1,10 +1,9 @@
 ---
 id: render
-title: render(element, container)
+title: render(element, containerNodeId)
 ---
 
-Render `element` at Figma `container`.
-
+Render `element` at Figma `containerNodeId`.
 
 ##### `element` (required)
 
@@ -22,9 +21,9 @@ Example:
   </Page>
 ```
 
-##### `container` (required)
+##### `containerNodeId` (optional)
 
-The element to render into. It's recommended to use `figma.root` or `figma.currentPage`.
+The figma container node id to render into. Defaults to the figma root nodes id (figma.root.id).
 
 #### Examples
 
@@ -65,6 +64,6 @@ const App = () => (
 );
 
 export default () => {
-  render(<App />, figma.currentPage);
+  render(<App />, figma.currentPage.id);
 };
 ``` 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -85,8 +85,8 @@ const renderInstance = (type, node, props) => {
     return result;
 };
 
-export const render = async (jsx: any) => {
-    const rootNode = await api.getInitialTree();
+export const render = async (jsx: any, targetNodeId?: string) => {
+    const rootNode = await api.getInitialTree(targetNodeId);
     prepareToHydration(rootNode, undefined);
 
     const HostConfig = {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -116,8 +116,9 @@ const findNodeByName = (children, name) => {
 
 export const api = createPluginAPI(
     {
-        getInitialTree() {
-            return getInitialTree(figma.root);
+        async getInitialTree(nodeId: string = figma.root.id) {
+            const node = figma.getNodeById(nodeId);
+            return getInitialTree(node);
         },
 
         renderInstance(type, _node, props, tempNode) {


### PR DESCRIPTION
Hey, thanks for this great library.

I noticed that, while the render function is documented to support rendering to a target container, it actually only supports rendering to the "root".

I wanted to be able to render different things to different locations based on some user interactions, which is not possible with this limitation.

I've managed to support my use case with a small tweak.

Something to note, if the render is passed a Page element and a non root node id, the page will be created with all it's children, but react-figma will throw because you can't move a page to node which isn't root.