### PR TITLE
Add missing but necessary step in setup guide

### DIFF
--- a/docs/api/render.md
+++ b/docs/api/render.md
@@ -1,6 +1,6 @@
 ---
 id: render
-title: render(element: ReactElement)
+title: render(element)
 ---
 
 Render React `element` into the Figma root node (current document). The only [Pages](./Page.md) allowed as first-class children.

--- a/docs/running.md
+++ b/docs/running.md
@@ -29,12 +29,24 @@ Go to `Menu > Plugins > Development > +` and select the `mainfest.json` file.
 
 <img src="/img/add-plugin.png" align="center"
      alt="Add Plugin" width="303" height="195" />
-     
+
 
 
 ## Running plugin
 
-Go to File Menu > Plugins > Development and select your plugin. 
+First start webpack:
+
+```
+yarn webpack:watch
+```
+
+Or with npm:
+
+```
+npm run webpack:watch
+```
+
+Then in Figma go to `File Menu > Plugins > Development` and select your plugin.
 It's expected result:
 
 ![running result](/img/running-result.png)


### PR DESCRIPTION
Hi, I noticed that there's a missing step in your 'running' guide. Without starting webpack, Figma won't load the plugin.

Apologies if I've misunderstood. At least for me, I had to run this script before Figma would allow me to open the plugin via `Plugins > Development > react-figma-boilerplate`. 