### PR TITLE
fix component set hydration

### DIFF
--- a/jsx-interfaces.d.ts
+++ b/jsx-interfaces.d.ts
@@ -8,8 +8,7 @@ import { ComponentProps } from './src/components/component/Component';
 import { StarProps } from './src/components/star/Star';
 import { VectorProps } from './src/components/vector/Vector';
 import { SliceProps } from './src/components/slice/Slice';
-import {ComponentSetProps} from "./src/components/component/ComponentSet";
-
+import { ComponentSetProps } from './src/components/component/ComponentSet';
 
 declare global {
     namespace JSX {
@@ -25,7 +24,7 @@ declare global {
             vector: VectorProps;
             instance: InstanceProps;
             slice: SliceProps;
-            componentset: ComponentSetProps
+            component_set: ComponentSetProps;
         }
     }
 }

--- a/src/components/component/ComponentSet.tsx
+++ b/src/components/component/ComponentSet.tsx
@@ -33,7 +33,7 @@ const ComponentSet: React.FC<ComponentSetProps> = props => {
 
     useOnLayoutHandler(yogaChildProps, props);
 
-    return <componentset {...componentProps} {...yogaChildProps} innerRef={nodeRef} />;
+    return <component_set {...componentProps} {...yogaChildProps} innerRef={nodeRef} />;
 };
 
 export { ComponentSet };

--- a/src/renderers/component_set.ts
+++ b/src/renderers/component_set.ts
@@ -12,7 +12,7 @@ const createNewComponentSet = () => {
     return figma.combineAsVariants([component], figma.currentPage);
 };
 
-export const componentset = node => props => {
+export const component_set = node => props => {
     const componentSetNode = node || props.node || createNewComponentSet();
 
     saveStyleMixin(componentSetNode)(props);

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -3,7 +3,7 @@ export { text } from './text';
 export { page } from './page';
 export { frame } from './frame';
 export { component } from './component';
-export { componentset } from './componentset';
+export { component_set } from './component_set';
 export { instance } from './instance';
 export { star } from './star';
 export { vector } from './vector';


### PR DESCRIPTION
I noticed that the component sets were not being rehydrated, and from investigation, this was due to logic that compares the figma node type name with the jsx component name.

An alternative to this change would be to special case the componentset component in the comparision code paths, but I wasn't sure if there were other places that similar comparisions were being made.