### PR TITLE
Support fillStyleId for Frames

### DIFF
--- a/src/mixins/frameMixin.ts
+++ b/src/mixins/frameMixin.ts
@@ -1,6 +1,6 @@
 import { propsAssign } from '../helpers/propsAssign';
 import { FrameProps } from '../types';
 
-export const frameMixin = propsAssign<FrameProps, FrameProps>(['backgrounds'], {
+export const frameMixin = propsAssign<FrameProps, FrameProps>(['backgrounds', 'fillStyleId'], {
     backgrounds: []
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface GeometryProps {
 
 export interface FrameProps {
     backgrounds?: ReadonlyArray<Paint>;
+    fillStyleId?: string | symbol;
 }
 
 export interface CornerProps {


### PR DESCRIPTION
## Context
For my use case, we're extending off of [this PR](https://github.com/react-figma/react-figma/pull/384) which allowed Components to take in a style prop.

[We want to leverage the new `useXStyle` hooks](https://react-figma.vercel.app/docs/local-styles) in order to:
- Create a new Color Style
- Apply the new Color style to a given component

This works fine for Views, but I noticed that this didn't work for Components.

## Debugging
When digging deeper, I found out that [this mixin](https://github.com/react-figma/react-figma/blob/master/src/renderers/component.ts#L31) is the problem. This mixin [carries over the background](https://github.com/react-figma/react-figma/blob/master/src/mixins/frameMixin.ts#L4-L6) prop from the component. Since it comes after [geometryMixin](https://github.com/react-figma/react-figma/blob/master/src/renderers/component.ts#L25) (which is [where the fillStyleId is initially carried over](https://github.com/react-figma/react-figma/blob/master/src/mixins/geometryMixin.ts#L13)), I believe this `background` is taking precedence and `fillStyleId` is being ignored.

## The fix(es)
As a fix, I'm just adding `fillStyleId` to also be carried over.

Another alternative could be to just change the order of the mixins, but that feels a bit fragile.

## Testing
I rendered a Component that took in `useFillPaintStyle`, and saw that its fill color was linked to the Color Styles on the file:

![Screen Shot 2021-12-16 at 3 54 45 PM](https://user-images.githubusercontent.com/96268806/146466061-9309b652-72fd-4ca4-a930-a1541e4ca259.png)
