### PR TITLE
Text fill style

### DIFF
--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -72,6 +72,7 @@ const Text: React.FC<TextProps> = props => {
         ...props,
         characters: charactersByChildren || props.characters,
         ...(style && style.textStyleId ? { textStyleId: style.textStyleId } : {}),
+        ...(style && style.fillStyleId ? { fillStyleId: style.fillStyleId } : {}),
         style,
         children
     };

--- a/src/localStyles/__tests__/__snapshots__/useTextStyle.test.tsx.snap
+++ b/src/localStyles/__tests__/__snapshots__/useTextStyle.test.tsx.snap
@@ -26,6 +26,7 @@ ChildrenMixinStub {
           },
           "effects": Array [],
           "exportSettings": Array [],
+          "fillStyleId": "S:test,",
           "fills": Array [
             Object {
               "color": Object {
@@ -57,7 +58,7 @@ ChildrenMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"fontFamily\\":\\"Roboto\\",\\"fontWeight\\":\\"bold\\",\\"fontSize\\":24,\\"color\\":\\"#000000\\",\\"textStyleId\\":\\"S:test,\\"}",
+            "reactStyle": "{\\"fontFamily\\":\\"Roboto\\",\\"fontWeight\\":\\"bold\\",\\"fontSize\\":24,\\"color\\":\\"#000000\\",\\"textStyleId\\":\\"S:test,\\",\\"fillStyleId\\":\\"S:test,\\"}",
           },
           "strokeAlign": "INSIDE",
           "strokeCap": "NONE",

--- a/src/localStyles/useCreateFillStyleId.ts
+++ b/src/localStyles/useCreateFillStyleId.ts
@@ -2,15 +2,15 @@ import { api } from '../rpc';
 import * as React from 'react';
 import { CommonStyleProps } from '../types';
 
-export const useCreateFillStyleId = (transformedStyles, params: CommonStyleProps) => {
+export const useCreateFillStyleId = (fills: symbol | readonly Paint[], params: CommonStyleProps) => {
     const [fillStyleId, setFillStyleId] = React.useState(null);
 
     const createFillsStyle = async () => {
-        if (!transformedStyles.fills) {
+        if (!fills) {
             return;
         }
         const id = await api.createOrUpdatePaintStyle({
-            paints: transformedStyles.fills,
+            paints: fills,
             params
         });
         setFillStyleId(id);

--- a/src/localStyles/useCreateFillStyleId.ts
+++ b/src/localStyles/useCreateFillStyleId.ts
@@ -1,0 +1,20 @@
+import { api } from '../rpc';
+import * as React from 'react';
+import { CommonStyleProps } from '../types';
+
+export const useCreateFillStyleId = (transformedStyles, params: CommonStyleProps) => {
+    const [fillStyleId, setFillStyleId] = React.useState(null);
+
+    const createFillsStyle = async () => {
+        if (!transformedStyles.fills) {
+            return;
+        }
+        const id = await api.createOrUpdatePaintStyle({
+            paints: transformedStyles.fills,
+            params
+        });
+        setFillStyleId(id);
+    };
+
+    return [createFillsStyle, fillStyleId];
+};

--- a/src/localStyles/useFillPaintStyle.ts
+++ b/src/localStyles/useFillPaintStyle.ts
@@ -17,7 +17,7 @@ export const useFillPaintStyle = (style: Partial<GeometryStyleProperties>, param
         ...transformGeometryStyleProperties('fills', style, imageHash),
         style
     };
-    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles, params);
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles.fills, params);
 
     React.useEffect(() => {
         if (Platform.OS !== 'figma') {

--- a/src/localStyles/useFillPaintStyle.ts
+++ b/src/localStyles/useFillPaintStyle.ts
@@ -8,30 +8,22 @@ import * as React from 'react';
 import { useImageHash } from '../hooks/useImageHash';
 import { Platform } from '../helpers/Platform';
 import { CommonStyleProps } from '../types';
+import { useCreateFillStyleId } from './useCreateFillStyleId';
 
 export const useFillPaintStyle = (style: Partial<GeometryStyleProperties>, params: CommonStyleProps) => {
-    const [fillStyleId, setFillStyleId] = React.useState(null);
     const imageHash = useImageHash(style.backgroundImage);
 
     const transformedStyles = {
         ...transformGeometryStyleProperties('fills', style, imageHash),
         style
     };
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles, params);
 
     React.useEffect(() => {
         if (Platform.OS !== 'figma') {
             return;
         }
-        const createFillsStyle = async () => {
-            if (!transformedStyles.fills) {
-                return;
-            }
-            const id = await api.createOrUpdatePaintStyle({
-                paints: transformedStyles.fills,
-                params
-            });
-            setFillStyleId(id);
-        };
+
         createFillsStyle();
     }, [transformedStyles]);
 

--- a/src/localStyles/useTextStyle.ts
+++ b/src/localStyles/useTextStyle.ts
@@ -4,6 +4,7 @@ import { TextStyleProperties, transformTextStyleProperties } from '../styleTrans
 import * as React from 'react';
 import { useFontName } from '../hooks/useFontName';
 import { CommonStyleProps } from '../types';
+import { useCreateFillStyleId } from './useCreateFillStyleId';
 
 const AVAILABLE_TEXT_PROPERTIES = [
     'fontSize',
@@ -18,7 +19,6 @@ const AVAILABLE_TEXT_PROPERTIES = [
 
 export const useTextStyle = (style: Partial<TextStyleProperties>, params: CommonStyleProps) => {
     const [textStyleId, setTextStyleId] = React.useState(null);
-    const [fillStyleId, setFillStyleId] = React.useState(null);
 
     const transformedStyles = React.useMemo(
         () => ({
@@ -27,6 +27,8 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
         }),
         [style]
     );
+
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles, params);
 
     const textProperties = React.useMemo(() => {
         return Object.keys(transformedStyles).reduce(
@@ -54,17 +56,6 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
                 loadedFont
             });
             setTextStyleId(id);
-        };
-
-        const createFillsStyle = async () => {
-            if (!transformedStyles.fills) {
-                return;
-            }
-            const id = await api.createOrUpdatePaintStyle({
-                paints: transformedStyles.fills,
-                params
-            });
-            setFillStyleId(id);
         };
 
         if (loadedFont) {

--- a/src/localStyles/useTextStyle.ts
+++ b/src/localStyles/useTextStyle.ts
@@ -18,6 +18,7 @@ const AVAILABLE_TEXT_PROPERTIES = [
 
 export const useTextStyle = (style: Partial<TextStyleProperties>, params: CommonStyleProps) => {
     const [textStyleId, setTextStyleId] = React.useState(null);
+    const [fillStyleId, setFillStyleId] = React.useState(null);
 
     const transformedStyles = React.useMemo(
         () => ({
@@ -40,7 +41,7 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
     const loadedFont = useFontName((textProperties as any).fontName || { family: 'Roboto', style: 'Regular' });
 
     React.useEffect(() => {
-        if (Platform.OS !== 'figma' || !loadedFont) {
+        if (Platform.OS !== 'figma') {
             return;
         }
         const createTextStyle = async () => {
@@ -54,8 +55,28 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
             });
             setTextStyleId(id);
         };
-        createTextStyle();
+
+        const createFillsStyle = async () => {
+            if (!transformedStyles.fills) {
+                return;
+            }
+            const id = await api.createOrUpdatePaintStyle({
+                paints: transformedStyles.fills,
+                params
+            });
+            setFillStyleId(id);
+        };
+
+        if (loadedFont) {
+            createTextStyle();
+        }
+
+        createFillsStyle();
     }, [textProperties, loadedFont]);
 
-    return { ...style, ...(textStyleId ? { textStyleId: textStyleId } : {}) };
+    return {
+        ...style,
+        ...(textStyleId ? { textStyleId: textStyleId } : {}),
+        ...(fillStyleId ? { fillStyleId: fillStyleId } : {})
+    };
 };

--- a/src/localStyles/useTextStyle.ts
+++ b/src/localStyles/useTextStyle.ts
@@ -28,7 +28,7 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
         [style]
     );
 
-    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles, params);
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles.fills, params);
 
     const textProperties = React.useMemo(() => {
         return Object.keys(transformedStyles).reduce(

--- a/src/styleTransformers/transformTextStyleProperties.ts
+++ b/src/styleTransformers/transformTextStyleProperties.ts
@@ -18,6 +18,7 @@ export interface TextStyleProperties {
     textShadowOffset: { width: number; height: number };
     textShadowRadius: number;
     textStyleId: string;
+    fillStyleId: string;
 }
 
 interface TextProperties extends GeometryProps, TextNodeProps {}


### PR DESCRIPTION
## Context
[A continuation of this PR](https://github.com/react-figma/react-figma/pull/483). Our team's trying to make use of the LocalStyles attached to a file, but we noticed that Text color styles weren't being applied properly - they'd just use the hardcoded colors.

## Debugging
I noticed that the [transformTextStyleProperties transformer](https://github.com/react-figma/react-figma/blob/master/src/styleTransformers/transformTextStyleProperties.ts#L49) converts any usage of `color` to be a `fill` property. From finding this, I saw how we added `fillStyleId` in [`useFillPaintStyle`](https://github.com/react-figma/react-figma/blob/master/src/localStyles/useFillPaintStyle.ts#L25-L34) and figured we could re-use that logic in Text.

I created the common `useCreateFillStyleId` hook and used it in `useTextStyle`.

I then updated the `Text` component to support the returned `fillStyleId` and updated the remaining type changes.


## Testing
I rendered a Component that took in `useTextStyle`, and saw that its fill color was linked to the Color Styles on the file:

![image](https://user-images.githubusercontent.com/96268806/146861381-623ab354-b55c-406c-82a3-d79d5c553b9f.png)
![image](https://user-images.githubusercontent.com/96268806/146861413-0deef453-629e-4e04-8c98-9f6b8dab20a3.png)


Also, the snapshot that was attached to the `useTextStyle` test was updated appropriately :D!
