### PR TITLE
Remove transparent background on View

### DIFF
--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -286,17 +286,7 @@ ChildrenMixinStub {
     ExportMixinStub {
       "children": Array [
         ExportMixinStub {
-          "backgrounds": Array [
-            Object {
-              "color": Object {
-                "b": 0,
-                "g": 0,
-                "r": 0,
-              },
-              "opacity": 0,
-              "type": "SOLID",
-            },
-          ],
+          "backgrounds": Array [],
           "blendMode": "NORMAL",
           "children": Array [
             LayoutMixinStub {
@@ -551,7 +541,7 @@ ChildrenMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"backgroundColor\\":\\"transparent\\"}",
+            "reactStyle": "{}",
           },
           "primaryAxisAlignItems": "MIN",
           "primaryAxisSizingMode": "AUTO",

--- a/src/components/view/View.tsx
+++ b/src/components/view/View.tsx
@@ -12,7 +12,6 @@ const View: React.FC<ViewProps> = props => {
             <Frame
                 {...props}
                 style={[
-                    { backgroundColor: 'transparent' },
                     (process.env.REACT_FIGMA_WEB_DEFAULTS_ENABLED &&
                         ((style as any).display === 'flex' || (style as any).display === 'inline-flex') && {
                             flexDirection: 'row'

--- a/src/components/view/__tests__/__snapshots__/View.test.tsx.snap
+++ b/src/components/view/__tests__/__snapshots__/View.test.tsx.snap
@@ -2,19 +2,6 @@
 
 exports[`<View /> View with children 1`] = `
 <frame
-  backgrounds={
-    Array [
-      Object {
-        "color": Object {
-          "b": 0,
-          "g": 0,
-          "r": 0,
-        },
-        "opacity": 0,
-        "type": "SOLID",
-      },
-    ]
-  }
   innerRef={
     Object {
       "current": undefined,
@@ -22,7 +9,6 @@ exports[`<View /> View with children 1`] = `
   }
   style={
     Object {
-      "backgroundColor": "transparent",
       "flex": 1,
     }
   }
@@ -174,19 +160,6 @@ exports[`<View /> View without children 1`] = `
 
 exports[`<View /> alignItems: "stretch" on web defaults mode 1`] = `
 <frame
-  backgrounds={
-    Array [
-      Object {
-        "color": Object {
-          "b": 0,
-          "g": 0,
-          "r": 0,
-        },
-        "opacity": 0,
-        "type": "SOLID",
-      },
-    ]
-  }
   innerRef={
     Object {
       "current": undefined,
@@ -195,7 +168,6 @@ exports[`<View /> alignItems: "stretch" on web defaults mode 1`] = `
   style={
     Object {
       "alignItems": "stretch",
-      "backgroundColor": "transparent",
     }
   }
 >
@@ -228,19 +200,6 @@ exports[`<View /> alignItems: "stretch" on web defaults mode 1`] = `
 
 exports[`<View /> flexDirection: "row" when display: flex on web defaults mode 1`] = `
 <frame
-  backgrounds={
-    Array [
-      Object {
-        "color": Object {
-          "b": 0,
-          "g": 0,
-          "r": 0,
-        },
-        "opacity": 0,
-        "type": "SOLID",
-      },
-    ]
-  }
   innerRef={
     Object {
       "current": undefined,
@@ -249,7 +208,6 @@ exports[`<View /> flexDirection: "row" when display: flex on web defaults mode 1
   style={
     Object {
       "alignItems": "stretch",
-      "backgroundColor": "transparent",
       "display": "flex",
       "flexDirection": "row",
     }

--- a/src/hooks/__tests__/__snapshots__/useInheritStyle.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useInheritStyle.tsx.snap
@@ -4,31 +4,11 @@ exports[`useInheritStyle havent propagating without REACT_FIGMA_STYLE_INHERITANC
 ExportMixinStub {
   "children": Array [
     ExportMixinStub {
-      "backgrounds": Array [
-        Object {
-          "color": Object {
-            "b": 0,
-            "g": 0,
-            "r": 0,
-          },
-          "opacity": 0,
-          "type": "SOLID",
-        },
-      ],
+      "backgrounds": Array [],
       "blendMode": "NORMAL",
       "children": Array [
         ExportMixinStub {
-          "backgrounds": Array [
-            Object {
-              "color": Object {
-                "b": 0,
-                "g": 0,
-                "r": 0,
-              },
-              "opacity": 0,
-              "type": "SOLID",
-            },
-          ],
+          "backgrounds": Array [],
           "blendMode": "NORMAL",
           "children": Array [
             ExportMixinStub {
@@ -157,7 +137,7 @@ ExportMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":48}",
+            "reactStyle": "{\\"fontSize\\":48}",
           },
           "primaryAxisAlignItems": "MIN",
           "primaryAxisSizingMode": "AUTO",
@@ -198,7 +178,7 @@ ExportMixinStub {
       "parent": [Circular],
       "pluginData": Object {
         "isReactFigmaNode": "true",
-        "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
+        "reactStyle": "{\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
       },
       "primaryAxisAlignItems": "MIN",
       "primaryAxisSizingMode": "AUTO",
@@ -238,31 +218,11 @@ exports[`useInheritStyle styles propagating works 1`] = `
 ExportMixinStub {
   "children": Array [
     ExportMixinStub {
-      "backgrounds": Array [
-        Object {
-          "color": Object {
-            "b": 0,
-            "g": 0,
-            "r": 0,
-          },
-          "opacity": 0,
-          "type": "SOLID",
-        },
-      ],
+      "backgrounds": Array [],
       "blendMode": "NORMAL",
       "children": Array [
         ExportMixinStub {
-          "backgrounds": Array [
-            Object {
-              "color": Object {
-                "b": 0,
-                "g": 0,
-                "r": 0,
-              },
-              "opacity": 0,
-              "type": "SOLID",
-            },
-          ],
+          "backgrounds": Array [],
           "blendMode": "NORMAL",
           "children": Array [
             ExportMixinStub {
@@ -395,7 +355,7 @@ ExportMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":48}",
+            "reactStyle": "{\\"fontSize\\":48}",
           },
           "primaryAxisAlignItems": "MIN",
           "primaryAxisSizingMode": "AUTO",
@@ -436,7 +396,7 @@ ExportMixinStub {
       "parent": [Circular],
       "pluginData": Object {
         "isReactFigmaNode": "true",
-        "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
+        "reactStyle": "{\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
       },
       "primaryAxisAlignItems": "MIN",
       "primaryAxisSizingMode": "AUTO",
@@ -476,17 +436,7 @@ exports[`useInheritStyle styles propagating works over component without useInhe
 ExportMixinStub {
   "children": Array [
     ExportMixinStub {
-      "backgrounds": Array [
-        Object {
-          "color": Object {
-            "b": 0,
-            "g": 0,
-            "r": 0,
-          },
-          "opacity": 0,
-          "type": "SOLID",
-        },
-      ],
+      "backgrounds": Array [],
       "blendMode": "NORMAL",
       "children": Array [
         LayoutMixinStub {
@@ -666,7 +616,7 @@ ExportMixinStub {
       "parent": [Circular],
       "pluginData": Object {
         "isReactFigmaNode": "true",
-        "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
+        "reactStyle": "{\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
       },
       "primaryAxisAlignItems": "MIN",
       "primaryAxisSizingMode": "AUTO",
@@ -706,31 +656,11 @@ exports[`useInheritStyle styles propagating works with wrapping to component 1`]
 ExportMixinStub {
   "children": Array [
     ExportMixinStub {
-      "backgrounds": Array [
-        Object {
-          "color": Object {
-            "b": 0,
-            "g": 0,
-            "r": 0,
-          },
-          "opacity": 0,
-          "type": "SOLID",
-        },
-      ],
+      "backgrounds": Array [],
       "blendMode": "NORMAL",
       "children": Array [
         ExportMixinStub {
-          "backgrounds": Array [
-            Object {
-              "color": Object {
-                "b": 0,
-                "g": 0,
-                "r": 0,
-              },
-              "opacity": 0,
-              "type": "SOLID",
-            },
-          ],
+          "backgrounds": Array [],
           "blendMode": "NORMAL",
           "children": Array [
             ExportMixinStub {
@@ -863,7 +793,7 @@ ExportMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":48}",
+            "reactStyle": "{\\"fontSize\\":48}",
           },
           "primaryAxisAlignItems": "MIN",
           "primaryAxisSizingMode": "AUTO",
@@ -904,7 +834,7 @@ ExportMixinStub {
       "parent": [Circular],
       "pluginData": Object {
         "isReactFigmaNode": "true",
-        "reactStyle": "{\\"backgroundColor\\":\\"transparent\\",\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
+        "reactStyle": "{\\"fontSize\\":50,\\"fontWeight\\":\\"bold\\",\\"fontFamily\\":\\"Roboto\\"}",
       },
       "primaryAxisAlignItems": "MIN",
       "primaryAxisSizingMode": "AUTO",

--- a/src/yoga/__tests__/__snapshots__/integration.test.tsx.snap
+++ b/src/yoga/__tests__/__snapshots__/integration.test.tsx.snap
@@ -12,17 +12,7 @@ ChildrenMixinStub {
     ExportMixinStub {
       "children": Array [
         ExportMixinStub {
-          "backgrounds": Array [
-            Object {
-              "color": Object {
-                "b": 0,
-                "g": 0,
-                "r": 0,
-              },
-              "opacity": 0,
-              "type": "SOLID",
-            },
-          ],
+          "backgrounds": Array [],
           "blendMode": "NORMAL",
           "children": Array [
             ExportMixinStub {
@@ -142,7 +132,7 @@ ChildrenMixinStub {
           "parent": [Circular],
           "pluginData": Object {
             "isReactFigmaNode": "true",
-            "reactStyle": "{\\"backgroundColor\\":\\"transparent\\"}",
+            "reactStyle": "{}",
           },
           "primaryAxisAlignItems": "MIN",
           "primaryAxisSizingMode": "AUTO",


### PR DESCRIPTION
Removing the { background: 'transparent' } styling on View. Our team maps colors to specific selector texts and this creates a hardcoded color on our component (#000000 with transparency of 0%) which we can't control unless we pass in a backgroundColor. 

Ran test and linter. Also sanity checked against examples/basic:
Before:
<img width="691" alt="Screen Shot 2022-01-27 at 3 49 33 PM" src="https://user-images.githubusercontent.com/6846913/151463364-1c5e45b6-8f74-4d15-bcd3-b46223c2854d.png"> 

After:
<img width="691" alt="Screen Shot 2022-01-27 at 3 48 20 PM" src="https://user-images.githubusercontent.com/6846913/151463387-32ea22a9-0e99-4a67-994e-450bb8509eaa.png">