### PR TITLE
[Local Styles] Fix fillStyleId from being created when there is no color in Text properties

### DIFF
--- a/src/localStyles/useTextStyle.ts
+++ b/src/localStyles/useTextStyle.ts
@@ -28,7 +28,7 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
         [style]
     );
 
-    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(transformedStyles.fills, params);
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(style && style.color ? transformedStyles.fills : null, params);
 
     const textProperties = React.useMemo(() => {
         return Object.keys(transformedStyles).reduce(

--- a/src/localStyles/useTextStyle.ts
+++ b/src/localStyles/useTextStyle.ts
@@ -28,7 +28,10 @@ export const useTextStyle = (style: Partial<TextStyleProperties>, params: Common
         [style]
     );
 
-    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(style && style.color ? transformedStyles.fills : null, params);
+    const [createFillsStyle, fillStyleId] = useCreateFillStyleId(
+        style && style.color ? transformedStyles.fills : null,
+        params
+    );
 
     const textProperties = React.useMemo(() => {
         return Object.keys(transformedStyles).reduce(

--- a/src/styleTransformers/transformTextStyleProperties.ts
+++ b/src/styleTransformers/transformTextStyleProperties.ts
@@ -1,11 +1,12 @@
 import { Color, GeometryProps, TextNodeProps } from '../types';
-import { colorToPaint, colorToRGB } from './transformColors';
+import { colorToPaint } from './transformColors';
 import { convertFontStyle } from './converFontStyle';
 import { transformDimensionMapper } from './transformDimension';
 import { transformShadowToEffect } from './transformShadowToEffect';
 
 export interface TextStyleProperties {
     color: string;
+    fillStyleId: string;
     fontFamily: string;
     fontWeight: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
     fontStyle: 'normal' | 'italic' | 'solid';
@@ -18,7 +19,6 @@ export interface TextStyleProperties {
     textShadowOffset: { width: number; height: number };
     textShadowRadius: number;
     textStyleId: string;
-    fillStyleId: string;
 }
 
 interface TextProperties extends GeometryProps, TextNodeProps {}


### PR DESCRIPTION
In `useTextStyle`, we pass in `transformedStyles.fills` as a check to see whether we should create a `fillStyleId`: https://github.com/react-figma/react-figma/blob/master/src/localStyles/useTextStyle.ts#L31 (early return if `transformedStyles.fills` does not exist: https://github.com/react-figma/react-figma/blob/c8654de55bb123cfafb8f075b76162925adf35fc/src/localStyles/useCreateFillStyleId.ts#L8-L11).

However, the above early return line never gets hit for `useTextStyle` because we always create a `fills` for its `transformedStyles`: https://github.com/react-figma/react-figma/blob/c8654de55bb123cfafb8f075b76162925adf35fc/src/styleTransformers/transformTextStyleProperties.ts#L50

This diff makes the change so that if we don't receive a `color` in the `style` then we make sure to pass in `null` in the `fills` argument so that we hit the early return block and don't create a `fillStyleId`. 

## Test (no color is passed in to the text style):
Before (we've created a `textStyleId` for `heading` and a `fillStyleId` for `heading` despite there being no color passed in):
<img width="1056" alt="Screen Shot 2022-02-01 at 8 16 09 PM" src="https://user-images.githubusercontent.com/6846913/152093179-33d9d920-dc87-4934-b7b2-aad18e476ec3.png">

After (we only created a `textStyleId` for heading. No `heading` color is created):
<img width="1103" alt="Screen Shot 2022-02-01 at 8 15 33 PM" src="https://user-images.githubusercontent.com/6846913/152093208-605a8543-e059-4c04-8d24-99eaf6bf6745.png">

