### PR TITLE
[Effect] Support shadow local style

### DIFF
--- a/docs/local-styles.md
+++ b/docs/local-styles.md
@@ -8,7 +8,7 @@ React Figma provides access to [Figma Styles API](https://www.figma.com/plugin-d
 #### useFillPaintStyle
 
 The `useFillPaintStyle` hook creates (or updates) [PaintStyle](https://www.figma.com/plugin-docs/api/PaintStyle/)
-and returns an object that contains `fillStyleId` and can be consumed in `style` prop. 
+and returns an object that contains `fillStyleId` and can be consumed in `style` prop.
 
 | Args       | Type     | Default | Note                                              |
 | ---------- | -------- | ------- | ------------------------------------------------- |
@@ -44,6 +44,22 @@ and returns an object that contains `textStyleId` and can be consumed in `style`
 | `params.name` | `String` |  | A style name |
 | `params.description` | `String` |  | A style description |
 
+#### useEffectStyle
+
+The `useEffectStyle` hook creates (or updates) [EffectStyle](https://www.figma.com/plugin-docs/api/EffectStyle/)
+and returns an object that contains `effectStyleId` and can be consumed in `style` prop.
+
+| Args       | Type     | Default | Note                                              |
+| ---------- | -------- | ------- | ------------------------------------------------- |
+| `style`     | [`Style`](/docs/styling) Object | | The `style` will applied to a local style |
+| `style.shadowType` | [`DROP_SHADOW`](https://www.figma.com/plugin-docs/api/Effect/#dropshadoweffect) or [`INNER_SHADOW`](https://www.figma.com/plugin-docs/api/Effect/#innershadoweffect) | `DROP_SHADOW` | Type of shadow effect |
+| `style.shadowSpread` | [`number`](https://www.figma.com/plugin-docs/api/Effect/#spread) | `0` | Shadow expansion distance |
+| `params` | `Object` |  |  |
+| `params.id` | `String` |  | A style id |
+| `params.name` | `String` |  | A style name |
+| `params.description` | `String` |  | A style description |
+
+
 #### Notes
 
 * Local styles hooks tried to find a style by `name` or `id`
@@ -55,7 +71,16 @@ and returns an object that contains `textStyleId` and can be consumed in `style`
 
 ```jsx
 import * as React from 'react';
-import { Page, View, Text, StyleSheet, useFillPaintStyle, useStrokePaintStyle, useTextStyle } from 'react-figma';
+import {
+    Page,
+    View,
+    Text,
+    StyleSheet,
+    useFillPaintStyle,
+    useStrokePaintStyle,
+    useTextStyle,
+    useEffectStyle
+} from 'react-figma';
 
 const styles = StyleSheet.create({
     root: {
@@ -68,12 +93,25 @@ const styles = StyleSheet.create({
         fontWeight: 'bold',
         fontSize: 24,
         color: '#000000'
+    },
+    innerShadow: {
+        shadowColor: '#0300AE',
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        shadowOffset: { width: -10, height: -10 }
+    },
+    dropShadow: {
+        shadowColor: '#E5187B',
+        shadowOpacity: 0.5,
+        shadowRadius: 4,
+        shadowOffset: { width: 2, height: 4 }
     }
 });
 
 export const App = () => {
     const rootFillStyle = useFillPaintStyle(styles.root, {
-        name: 'root/background'
+        name: 'root/background',
+        description: 'Background color'
     });
 
     const rootStrokeStyle = useStrokePaintStyle(styles.root, {
@@ -84,14 +122,34 @@ export const App = () => {
         name: 'heading'
     });
 
+    const shadowStyle = useEffectStyle(
+        {
+            shadows: [
+                { ...styles.innerShadow, shadowType: 'INNER_SHADOW', shadowSpread: 2 },
+                { ...styles.dropShadow, shadowType: 'DROP_SHADOW' }
+            ]
+        },
+        {
+            name: 'Shadow Effect'
+        }
+    );
+
     return (
         <Page name="New page" isCurrent>
             <View>
-                <View style={{ width: 200, height: 100, ...styles.root, ...rootFillStyle, ...rootStrokeStyle }} />
+                <View
+                    style={{
+                        width: 200,
+                        height: 100,
+                        ...styles.root,
+                        ...rootFillStyle,
+                        ...rootStrokeStyle,
+                        ...shadowStyle
+                    }}
+                />
                 <Text style={{ ...headingTextStyle }}>Local styles</Text>
             </View>
         </Page>
     );
 };
 ```
-

--- a/examples/local-styles/src/App.tsx
+++ b/examples/local-styles/src/App.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Page, View, Text, StyleSheet, useFillPaintStyle, useStrokePaintStyle, useTextStyle } from 'react-figma';
+import {
+    Page,
+    View,
+    Text,
+    StyleSheet,
+    useFillPaintStyle,
+    useStrokePaintStyle,
+    useTextStyle,
+    useEffectStyle
+} from 'react-figma';
 
 const styles = StyleSheet.create({
     root: {
@@ -12,6 +21,18 @@ const styles = StyleSheet.create({
         fontWeight: 'bold',
         fontSize: 24,
         color: '#000000'
+    },
+    innerShadow: {
+        shadowColor: '#0300AE',
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        shadowOffset: { width: -10, height: -10 }
+    },
+    dropShadow: {
+        shadowColor: '#E5187B',
+        shadowOpacity: 0.5,
+        shadowRadius: 4,
+        shadowOffset: { width: 2, height: 4 }
     }
 });
 
@@ -29,10 +50,31 @@ export const App = () => {
         name: 'heading'
     });
 
+    const shadowStyle = useEffectStyle(
+        {
+            shadows: [
+                { ...styles.innerShadow, shadowType: 'INNER_SHADOW', shadowSpread: 2 },
+                { ...styles.dropShadow, shadowType: 'DROP_SHADOW' }
+            ]
+        },
+        {
+            name: 'Shadow Effect'
+        }
+    );
+
     return (
         <Page name="New page" isCurrent>
             <View>
-                <View style={{ width: 200, height: 100, ...styles.root, ...rootFillStyle, ...rootStrokeStyle }} />
+                <View
+                    style={{
+                        width: 200,
+                        height: 100,
+                        ...styles.root,
+                        ...rootFillStyle,
+                        ...rootStrokeStyle,
+                        ...shadowStyle
+                    }}
+                />
                 <Text style={{ ...headingTextStyle }}>Local styles</Text>
             </View>
         </Page>

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,3 +32,4 @@ export { NativeModules } from './rn/NativeModules';
 export { useFillPaintStyle } from './localStyles/useFillPaintStyle';
 export { useStrokePaintStyle } from './localStyles/useStrokePaintStyle';
 export { useTextStyle } from './localStyles/useTextStyle';
+export { useEffectStyle } from './localStyles/useEffectStyle';

--- a/src/localStyles/useCreateEffectStyleId.ts
+++ b/src/localStyles/useCreateEffectStyleId.ts
@@ -1,0 +1,20 @@
+import { api } from '../rpc';
+import * as React from 'react';
+import { CommonStyleProps } from '../types';
+
+export const useCreateEffectStyleId = (effects: symbol | readonly Effect[], params: CommonStyleProps) => {
+    const [effectStyleId, setEffectStyleId] = React.useState(null);
+
+    const createEffectStyle = async () => {
+        if (!effects) {
+            return;
+        }
+        const id = await api.createOrUpdateEffectStyle({
+            effects,
+            params
+        });
+        setEffectStyleId(id);
+    };
+
+    return [createEffectStyle, effectStyleId];
+};

--- a/src/localStyles/useEffectStyle.ts
+++ b/src/localStyles/useEffectStyle.ts
@@ -1,0 +1,24 @@
+import { api } from '../rpc';
+import * as React from 'react';
+import { Platform } from '../helpers/Platform';
+import { CommonStyleProps } from '../types';
+import { BlendStyleProperties, transformBlendProperties } from '../styleTransformers/transformBlendProperties';
+import { useCreateEffectStyleId } from './useCreateEffectStyleId';
+
+export const useEffectStyle = (style: Partial<BlendStyleProperties>, params: CommonStyleProps) => {
+    const transformedStyles = {
+        ...transformBlendProperties(style),
+        style
+    };
+    const [createEffectStyle, effectStyleId] = useCreateEffectStyleId(transformedStyles.effects, params);
+
+    React.useEffect(() => {
+        if (Platform.OS !== 'figma') {
+            return;
+        }
+
+        createEffectStyle();
+    }, [transformedStyles]);
+
+    return { ...style, ...(effectStyleId ? { effectStyleId } : {}) };
+};

--- a/src/mixins/blendMixin.ts
+++ b/src/mixins/blendMixin.ts
@@ -2,7 +2,7 @@ import { BlendProps } from '../types';
 import { propsAssign } from '../helpers/propsAssign';
 
 export const blendMixin = propsAssign<BlendProps, BlendProps>(
-    ['blendMode', 'effectStyleId', 'effects', 'isMask', 'opacity'],
+    ['blendMode', 'effects', 'isMask', 'opacity', 'effectStyleId'],
     {
         blendMode: 'NORMAL',
         effects: [],

--- a/src/renderers/__tests__/rectangle.test.ts
+++ b/src/renderers/__tests__/rectangle.test.ts
@@ -1,0 +1,19 @@
+import { createFigma } from 'figma-api-stub';
+import { rectangle } from '../rectangle';
+
+describe('rectangle renderer', () => {
+    beforeEach(() => {
+        // @ts-ignore
+        global.figma = createFigma({
+            simulateErrors: true
+        });
+    });
+
+    it('effectStyleId applied', () => {
+        const rectangleNode = rectangle(null)({
+            effectStyleId: 'effectStyleIdTest',
+            effects: [{ type: 'LAYER_BLUR', radius: 4, visible: true }]
+        });
+        expect(rectangleNode.effectStyleId).toEqual('effectStyleIdTest');
+    });
+});

--- a/src/renderers/rectangle.ts
+++ b/src/renderers/rectangle.ts
@@ -1,9 +1,7 @@
 import { baseNodeMixin } from '../mixins/baseNodeMixin';
 import { layoutMixin } from '../mixins/layoutMixin';
-import { BorderProps } from '../types';
 import { geometryMixin } from '../mixins/geometryMixin';
 import { saveStyleMixin } from '../mixins/saveStyleMixin';
-import { propsAssign } from '../helpers/propsAssign';
 import { RectangleProps } from '../components/rectangle/Rectangle';
 import { cornerMixin } from '../mixins/cornerMixin';
 import { exportMixin } from '../mixins/exportMixin';

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -254,6 +254,26 @@ export const api = createPluginAPI(
                 });
             }
             return textStyle.id;
+        },
+
+        createOrUpdateEffectStyle(properties: {
+            effects: ReadonlyArray<Effect> | symbol | void;
+            params: CommonStyleProps;
+        }) {
+            const { effects, params } = properties;
+            const { name, id, description } = params;
+            const foundEffectStyle = figma.getLocalEffectStyles().find(style => style.name === name || style.id === id);
+            const effectStyle = foundEffectStyle || figma.createEffectStyle();
+            if (name) {
+                effectStyle.name = name;
+            }
+            if (description) {
+                effectStyle.description = description;
+            }
+            if (effects) {
+                effectStyle.effects = effects as any;
+            }
+            return effectStyle.id;
         }
     },
     {

--- a/src/styleTransformers/__tests__/__snapshots__/transformShadowToEffect.test.ts.snap
+++ b/src/styleTransformers/__tests__/__snapshots__/transformShadowToEffect.test.ts.snap
@@ -15,6 +15,7 @@ Array [
       "y": 0,
     },
     "radius": 0,
+    "spread": 0,
     "type": "DROP_SHADOW",
     "visible": true,
   },

--- a/src/styleTransformers/__tests__/__snapshots__/transformTextStyleProperties.test.ts.snap
+++ b/src/styleTransformers/__tests__/__snapshots__/transformTextStyleProperties.test.ts.snap
@@ -115,6 +115,7 @@ Object {
         "y": 20,
       },
       "radius": 15,
+      "spread": 0,
       "type": "DROP_SHADOW",
       "visible": true,
     },

--- a/src/styleTransformers/transformBlendProperties.ts
+++ b/src/styleTransformers/transformBlendProperties.ts
@@ -24,15 +24,18 @@ export interface ShadowProperties {
     shadowOffset?: { width: number; height: number };
     shadowOpacity: number;
     shadowRadius?: number;
+    shadowSpread?: number;
+    shadowType?: 'DROP_SHADOW' | 'INNER_SHADOW';
 }
 
 export interface BlendStyleProperties extends ShadowProperties {
     opacity: number;
     blendMode: CSSBlendMode;
     shadows?: ShadowProperties[];
+    effectStyleId?: string;
 }
 
-const transofrmBlendMode = (cssBlendMode: CSSBlendMode): BlendMode => {
+const transformBlendMode = (cssBlendMode: CSSBlendMode): BlendMode => {
     /**
      * TODO: Missing modes - PASS_THROUGH, LINEAR_BURN, LINEAR_DODGE
      */
@@ -74,7 +77,9 @@ const transofrmBlendMode = (cssBlendMode: CSSBlendMode): BlendMode => {
     }
 };
 
-export const transformBlendProperties = (styles?: Partial<BlendStyleProperties>): BlendProps => {
+export const transformBlendProperties = (
+    styles?: Partial<BlendStyleProperties> & { effectStyleId?: string }
+): BlendProps => {
     if (!styles) {
         return {};
     }
@@ -85,12 +90,12 @@ export const transformBlendProperties = (styles?: Partial<BlendStyleProperties>)
         blendProps.opacity = styles.opacity;
     }
     if (styles.blendMode) {
-        blendProps.blendMode = transofrmBlendMode(styles.blendMode);
+        blendProps.blendMode = transformBlendMode(styles.blendMode);
     }
 
     if (styles.shadowColor || styles.shadows) {
         blendProps.effects = transformShadowToEffect(styles);
     }
 
-    return blendProps;
+    return { ...blendProps, ...((styles.effectStyleId && { effectStyleId: styles.effectStyleId }) || {}) };
 };

--- a/src/styleTransformers/transformShadowToEffect.ts
+++ b/src/styleTransformers/transformShadowToEffect.ts
@@ -7,7 +7,7 @@ export const transformShadowToEffect = (styles: Partial<BlendStyleProperties>): 
         shadows = styles.shadows;
     }
     return shadows.map(shadow => ({
-        type: 'DROP_SHADOW',
+        type: shadow.shadowType != null ? shadow.shadowType : 'DROP_SHADOW',
         color: colorToRGBA(shadow.shadowColor, shadow.shadowOpacity),
         offset: shadow.shadowOffset
             ? {
@@ -19,6 +19,7 @@ export const transformShadowToEffect = (styles: Partial<BlendStyleProperties>): 
                   y: 0
               },
         radius: shadow.shadowRadius || 0,
+        spread: shadow.shadowSpread || 0,
         visible: true,
         blendMode: 'NORMAL'
     }));


### PR DESCRIPTION
# Context
PR supports `useEffectStyle` to create shadow effects as local style. The hook utilizes [transformBlendProperties.ts](https://github.com/react-figma/react-figma/compare/master...annuhdo:shadowEffect?expand=1#diff-2c7d98b4e508d3a4a6e27470c2859f127dcf398835d22810120affe83619fc9c) and [transformShadowToEffect.ts](https://github.com/react-figma/react-figma/compare/master...annuhdo:shadowEffect?expand=1#diff-7779ea6e4b4ea5a573bd1e9dddc44a9778b334cec847062d5def06726340b1a9) to transform style into the appropriate properties for a [Drop Shadow or Inner Shadow effect](https://www.figma.com/plugin-docs/api/Effect).

# Test
https://user-images.githubusercontent.com/6846913/154370850-18546319-9a9b-4c4c-9f74-d981fb1dad72.mov

