### PR TITLE
[Effect] (2) Support blur effect style

### DIFF
--- a/docs/local-styles.md
+++ b/docs/local-styles.md
@@ -53,7 +53,8 @@ and returns an object that contains `effectStyleId` and can be consumed in `styl
 | ---------- | -------- | ------- | ------------------------------------------------- |
 | `style`     | [`Style`](/docs/styling) Object | | The `style` will applied to a local style |
 | `style.shadowType` | [`DROP_SHADOW`](https://www.figma.com/plugin-docs/api/Effect/#dropshadoweffect) or [`INNER_SHADOW`](https://www.figma.com/plugin-docs/api/Effect/#innershadoweffect) | `DROP_SHADOW` | Type of shadow effect |
-| `style.shadowSpread` | [`number`](https://www.figma.com/plugin-docs/api/Effect/#spread) | `0` | Shadow expansion distance |
+| `style.blurType` | [`LAYER_BLUR or BACKGROUND_BLUR`](https://www.figma.com/plugin-docs/api/Effect/#blureffect) | `LAYER_BLUR` | Type of blur effect |
+| `style.blurRadius` | `number` | `0` | Blur radius. Must be >= 0 |
 | `params` | `Object` |  |  |
 | `params.id` | `String` |  | A style id |
 | `params.name` | `String` |  | A style name |
@@ -88,6 +89,11 @@ const styles = StyleSheet.create({
         borderColor: '#ffffff',
         borderWidth: 5
     },
+    blurContainer: {
+        backgroundColor: '#30885E',
+        borderColor: '#ffffff',
+        borderWidth: 5
+    },
     heading: {
         fontFamily: 'Roboto',
         fontWeight: 'bold',
@@ -105,6 +111,9 @@ const styles = StyleSheet.create({
         shadowOpacity: 0.5,
         shadowRadius: 4,
         shadowOffset: { width: 2, height: 4 }
+    },
+    layerBlur: {
+        blurRadius: 4
     }
 });
 
@@ -112,6 +121,11 @@ export const App = () => {
     const rootFillStyle = useFillPaintStyle(styles.root, {
         name: 'root/background',
         description: 'Background color'
+    });
+
+    const blurFillStyle = useFillPaintStyle(styles.blurContainer, {
+        name: 'blur/background',
+        description: 'Blur Background color'
     });
 
     const rootStrokeStyle = useStrokePaintStyle(styles.root, {
@@ -134,6 +148,16 @@ export const App = () => {
         }
     );
 
+    const blurShadowElevationStyle = useEffectStyle(
+        {
+            shadows: [{ ...styles.innerShadow, shadowType: 'INNER_SHADOW' }],
+            blurs: [{ ...styles.layerBlur, blurType: 'LAYER_BLUR' }]
+        },
+        {
+            name: 'Blur Shadow Effect'
+        }
+    );
+
     return (
         <Page name="New page" isCurrent>
             <View>
@@ -145,6 +169,15 @@ export const App = () => {
                         ...rootFillStyle,
                         ...rootStrokeStyle,
                         ...shadowStyle
+                    }}
+                />
+                <View
+                    style={{
+                        width: 200,
+                        height: 50,
+                        ...blurFillStyle,
+                        ...rootStrokeStyle,
+                        ...blurShadowElevationStyle
                     }}
                 />
                 <Text style={{ ...headingTextStyle }}>Local styles</Text>

--- a/examples/local-styles/src/App.tsx
+++ b/examples/local-styles/src/App.tsx
@@ -16,6 +16,11 @@ const styles = StyleSheet.create({
         borderColor: '#ffffff',
         borderWidth: 5
     },
+    blurContainer: {
+        backgroundColor: '#30885E',
+        borderColor: '#ffffff',
+        borderWidth: 5
+    },
     heading: {
         fontFamily: 'Roboto',
         fontWeight: 'bold',
@@ -33,6 +38,9 @@ const styles = StyleSheet.create({
         shadowOpacity: 0.5,
         shadowRadius: 4,
         shadowOffset: { width: 2, height: 4 }
+    },
+    layerBlur: {
+        blurRadius: 4
     }
 });
 
@@ -40,6 +48,11 @@ export const App = () => {
     const rootFillStyle = useFillPaintStyle(styles.root, {
         name: 'root/background',
         description: 'Background color'
+    });
+
+    const blurFillStyle = useFillPaintStyle(styles.blurContainer, {
+        name: 'blur/background',
+        description: 'Blur Background color'
     });
 
     const rootStrokeStyle = useStrokePaintStyle(styles.root, {
@@ -62,6 +75,16 @@ export const App = () => {
         }
     );
 
+    const blurShadowElevationStyle = useEffectStyle(
+        {
+            shadows: [{ ...styles.innerShadow, shadowType: 'INNER_SHADOW' }],
+            blurs: [{ ...styles.layerBlur, blurType: 'LAYER_BLUR' }]
+        },
+        {
+            name: 'Blur Shadow Effect'
+        }
+    );
+
     return (
         <Page name="New page" isCurrent>
             <View>
@@ -73,6 +96,15 @@ export const App = () => {
                         ...rootFillStyle,
                         ...rootStrokeStyle,
                         ...shadowStyle
+                    }}
+                />
+                <View
+                    style={{
+                        width: 200,
+                        height: 50,
+                        ...blurFillStyle,
+                        ...rootStrokeStyle,
+                        ...blurShadowElevationStyle
                     }}
                 />
                 <Text style={{ ...headingTextStyle }}>Local styles</Text>

--- a/src/styleTransformers/__tests__/__snapshots__/transformBlurToEffect.test.ts.snap
+++ b/src/styleTransformers/__tests__/__snapshots__/transformBlurToEffect.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transformBlurToEffect blur radius 1`] = `
+Array [
+  Object {
+    "radius": 4,
+    "type": "LAYER_BLUR",
+    "visible": true,
+  },
+]
+`;

--- a/src/styleTransformers/__tests__/transformBlurToEffect.test.ts
+++ b/src/styleTransformers/__tests__/transformBlurToEffect.test.ts
@@ -1,0 +1,10 @@
+import { transformBlurToEffect } from '../transformBlurToEffect';
+
+describe('transformBlurToEffect', () => {
+    it('blur radius', () => {
+        const result = transformBlurToEffect({
+            blurRadius: 4
+        });
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/src/styleTransformers/transformBlendProperties.ts
+++ b/src/styleTransformers/transformBlendProperties.ts
@@ -1,4 +1,5 @@
 import { BlendProps, Color } from '../types';
+import { transformBlurToEffect } from './transformBlurToEffect';
 import { transformShadowToEffect } from './transformShadowToEffect';
 
 export type CSSBlendMode =
@@ -19,6 +20,11 @@ export type CSSBlendMode =
     | 'color'
     | 'luminosity';
 
+export interface BlurProperties {
+    blurRadius?: number;
+    blurType?: 'LAYER_BLUR' | 'BACKGROUND_BLUR';
+}
+
 export interface ShadowProperties {
     shadowColor: Color;
     shadowOffset?: { width: number; height: number };
@@ -28,10 +34,11 @@ export interface ShadowProperties {
     shadowType?: 'DROP_SHADOW' | 'INNER_SHADOW';
 }
 
-export interface BlendStyleProperties extends ShadowProperties {
+export interface BlendStyleProperties extends ShadowProperties, BlurProperties {
     opacity: number;
     blendMode: CSSBlendMode;
     shadows?: ShadowProperties[];
+    blurs?: BlurProperties[];
     effectStyleId?: string;
 }
 
@@ -94,7 +101,17 @@ export const transformBlendProperties = (
     }
 
     if (styles.shadowColor || styles.shadows) {
-        blendProps.effects = transformShadowToEffect(styles);
+        blendProps.effects = [
+            ...(blendProps.effects != null ? blendProps.effects : []),
+            ...transformShadowToEffect(styles)
+        ];
+    }
+
+    if (styles.blurRadius || styles.blurs) {
+        blendProps.effects = [
+            ...(blendProps.effects != null ? blendProps.effects : []),
+            ...transformBlurToEffect(styles)
+        ];
     }
 
     return { ...blendProps, ...((styles.effectStyleId && { effectStyleId: styles.effectStyleId }) || {}) };

--- a/src/styleTransformers/transformBlurToEffect.ts
+++ b/src/styleTransformers/transformBlurToEffect.ts
@@ -1,0 +1,14 @@
+import { colorToRGBA } from './transformColors';
+import { BlurProperties, BlendStyleProperties } from './transformBlendProperties';
+
+export const transformBlurToEffect = (styles: Partial<BlendStyleProperties>): BlurEffect[] => {
+    let blurs: Partial<BlurProperties>[] = [styles];
+    if ('blurs' in styles && Array.isArray(styles.shadows)) {
+        blurs = styles.blurs;
+    }
+    return blurs.map(blur => ({
+        type: blur.blurType != null ? blur.blurType : 'LAYER_BLUR',
+        radius: blur.blurRadius || 0,
+        visible: true
+    }));
+};


### PR DESCRIPTION
# Context
I'm working on supporting `useEffectStyle` for local styles. This diff supports blur effects. This is the second part to the [PR that supports shadow effects](https://github.com/react-figma/react-figma/pull/500).

**Edit:** I think I got confused as to how git works but this should be stacked on top of #500 :( The only commit I need reviewing is 103eeb1. The other commit 57ba720 is in PR #500.

# Test

https://user-images.githubusercontent.com/6846913/154373669-d65f7d08-de9e-49d9-ae11-6eccfc7efb84.mov


