### PR TITLE
Add support for Page backgrounds

### DIFF
--- a/docs/api/Page.md
+++ b/docs/api/Page.md
@@ -16,6 +16,7 @@ Figma document (`figma.root`) should be a parent.
 | `style`    | [`Style`](/docs/styling)   |         | Only layout props                                                 |
 | `isCurrent`| `Boolean`|         | Make page current                                 |
 | `onCurrentChange` | `Function` | | Changing current page callback |
+| `backgrounds` | `Paint[]` | | Zero or one fill styles for the page |
 | `onLayout` | `Function` |  | Event is fired once the layout has been calculated  |
 | `onNodeId` | `Fuction` | | Getting Figma Node ID callback |  
 

--- a/examples/page-background/manifest.json
+++ b/examples/page-background/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Page Background",
+  "id": "741371398137186725",
+  "api": "1.0.0",
+  "main": "dist/code.js",
+  "ui": "dist/ui.html",
+  "editorType": ["figma"]
+}

--- a/examples/page-background/package.json
+++ b/examples/page-background/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "page-background",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "webpack:watch": "webpack --watch"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/page-background/src/App.tsx
+++ b/examples/page-background/src/App.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { Page, View } from 'react-figma';
+
+export const App = () => {
+    return (
+            <Page name="New page" style={{ backgroundColor: '#ff0000' }}>
+                <View>
+                    <View style={{ width: 200, height: 100, backgroundColor: '#ffffff' }} />
+                </View>
+            </Page>
+    );
+};

--- a/examples/page-background/src/App.tsx
+++ b/examples/page-background/src/App.tsx
@@ -3,10 +3,10 @@ import { Page, View } from 'react-figma';
 
 export const App = () => {
     return (
-            <Page name="New page" style={{ backgroundColor: '#ff0000' }}>
-                <View>
-                    <View style={{ width: 200, height: 100, backgroundColor: '#ffffff' }} />
-                </View>
-            </Page>
+        <Page name="New page" style={{ backgroundColor: '#ff0000' }}>
+            <View>
+                <View style={{ width: 200, height: 100, backgroundColor: '#ffffff' }} />
+            </View>
+        </Page>
     );
 };

--- a/examples/page-background/src/code.tsx
+++ b/examples/page-background/src/code.tsx
@@ -1,0 +1,5 @@
+import { setupMainThread } from 'react-figma/rpc';
+
+figma.showUI(__html__, { visible: false });
+
+setupMainThread();

--- a/examples/page-background/src/ui.tsx
+++ b/examples/page-background/src/ui.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { App } from './App';
+
+import 'react-figma/rpc';
+import { render } from 'react-figma';
+
+render(<App />);

--- a/examples/page-background/tsconfig.json
+++ b/examples/page-background/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es5", "es6", "es7", "es2017", "dom"],
+    "sourceMap": true,
+    "allowJs": false,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "rootDirs": ["src"],
+    "baseUrl": "src",
+    "skipLibCheck": true,
+    "declaration": true,
+    "paths": {
+      "react-figma": ["../../../src/index.ts"],
+      "react-figma/rpc": ["../../../src/rpc.ts"]
+    },
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules/@figma"
+    ]
+  },
+  "include": ["src/**/*", "../../jsx-interfaces.d.ts", "../../images.d.ts"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"]
+}

--- a/examples/page-background/webpack.config.js
+++ b/examples/page-background/webpack.config.js
@@ -1,0 +1,11 @@
+var configure = require('react-figma-webpack-config');
+
+module.exports = configure({
+    resolve: {
+        extensions: ['.tsx', '.ts', '.jsx', '.js'],
+        alias: {
+            'react-figma$': '../../../src',
+            'react-figma/rpc$': '../../../src/rpc'
+        }
+    }
+});

--- a/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [],
@@ -284,6 +285,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [
@@ -591,6 +593,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [],
       "exportSettings": Array [],
       "id": "1:1",
@@ -617,6 +620,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [],
@@ -685,6 +689,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [],
@@ -755,6 +760,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [],
@@ -823,6 +829,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "some text",
@@ -905,6 +912,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "Some text",
@@ -987,6 +995,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "Some text 2",
@@ -1071,6 +1080,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "text 2",
@@ -1155,6 +1165,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "some text",
@@ -1241,6 +1252,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "1/2",
@@ -1323,6 +1335,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         LayoutMixinStub {
           "backgrounds": Array [],
@@ -1555,6 +1568,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         LayoutMixinStub {
           "backgrounds": Array [],
@@ -1787,6 +1801,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         LayoutMixinStub {
           "backgrounds": Array [],
@@ -2033,6 +2048,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         LayoutMixinStub {
           "backgrounds": Array [],
@@ -2246,6 +2262,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         LayoutMixinStub {
           "backgrounds": Array [],
@@ -2335,6 +2352,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2515,6 +2533,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2624,6 +2643,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2733,6 +2753,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2801,6 +2822,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2869,6 +2891,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",
@@ -2978,6 +3001,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -6,9 +6,15 @@ import { $currentPageTempId, api } from '../../rpc';
 import { map } from 'rxjs/operators';
 import { OnLayoutHandlerProps, useOnLayoutHandler } from '../../hooks/useOnLayoutHandler';
 import { InheritStyleProvider } from '../../hooks/useInheritStyle';
+import {
+    GeometryStyleProperties,
+    transformGeometryStyleProperties
+} from "../../styleTransformers/transformGeometryStyleProperties";
+import {StyleSheet} from "../../helpers/StyleSheet";
+import {useImageHash} from "../../hooks/useImageHash";
 
 export interface PageProps extends BaseNodeProps, ChildrenProps, ExportProps, OnLayoutHandlerProps {
-    style?: StyleOf<YogaStyleProperties>;
+    style?: StyleOf<YogaStyleProperties & GeometryStyleProperties>;
     isCurrent?: boolean;
     onCurrentChange?: (isCurrent: boolean) => void;
     backgrounds?: ReadonlyArray<Paint>;
@@ -43,9 +49,19 @@ const Page: React.FC<PageProps> = props => {
     const yogaChildProps = useYogaLayout({ nodeRef, ...otherProps });
     useOnLayoutHandler(yogaChildProps, props);
 
+    const style = StyleSheet.flatten(props.style);
+
+    const imageHash = useImageHash(style.backgroundImage);
+
+    const pageProps = {
+        ...transformGeometryStyleProperties('backgrounds', style, imageHash),
+        ...otherProps,
+        style
+    };
+
     return (
         <InheritStyleProvider style={props.style}>
-            <page {...otherProps} {...yogaChildProps} innerRef={nodeRef} />
+            <page {...pageProps} {...yogaChildProps} innerRef={nodeRef} />
         </InheritStyleProvider>
     );
 };

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -11,6 +11,7 @@ export interface PageProps extends BaseNodeProps, ChildrenProps, ExportProps, On
     style?: StyleOf<YogaStyleProperties>;
     isCurrent?: boolean;
     onCurrentChange?: (isCurrent: boolean) => void;
+    backgrounds?: ReadonlyArray<Paint>;
 }
 
 export const useCurrentPageChange = (

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -9,9 +9,9 @@ import { InheritStyleProvider } from '../../hooks/useInheritStyle';
 import {
     GeometryStyleProperties,
     transformGeometryStyleProperties
-} from "../../styleTransformers/transformGeometryStyleProperties";
-import {StyleSheet} from "../../helpers/StyleSheet";
-import {useImageHash} from "../../hooks/useImageHash";
+} from '../../styleTransformers/transformGeometryStyleProperties';
+import { StyleSheet } from '../../helpers/StyleSheet';
+import { useImageHash } from '../../hooks/useImageHash';
 
 export interface PageProps extends BaseNodeProps, ChildrenProps, ExportProps, OnLayoutHandlerProps {
     style?: StyleOf<YogaStyleProperties & GeometryStyleProperties>;

--- a/src/components/rectangle/__tests__/__snapshots__/Rectangle.test.tsx.snap
+++ b/src/components/rectangle/__tests__/__snapshots__/Rectangle.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",

--- a/src/hooks/__tests__/__snapshots__/useInheritStyle.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useInheritStyle.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`useInheritStyle havent propagating without REACT_FIGMA_STYLE_INHERITANCE_ENABLED flag 1`] = `
 ExportMixinStub {
+  "backgrounds": Array [],
   "children": Array [
     ExportMixinStub {
       "backgrounds": Array [
@@ -236,6 +237,7 @@ ExportMixinStub {
 
 exports[`useInheritStyle styles propagating works 1`] = `
 ExportMixinStub {
+  "backgrounds": Array [],
   "children": Array [
     ExportMixinStub {
       "backgrounds": Array [
@@ -474,6 +476,7 @@ ExportMixinStub {
 
 exports[`useInheritStyle styles propagating works over component without useInheritStyle 1`] = `
 ExportMixinStub {
+  "backgrounds": Array [],
   "children": Array [
     ExportMixinStub {
       "backgrounds": Array [
@@ -704,6 +707,7 @@ ExportMixinStub {
 
 exports[`useInheritStyle styles propagating works with wrapping to component 1`] = `
 ExportMixinStub {
+  "backgrounds": Array [],
   "children": Array [
     ExportMixinStub {
       "backgrounds": Array [

--- a/src/localStyles/__tests__/__snapshots__/useFillPaintStyle.test.tsx.snap
+++ b/src/localStyles/__tests__/__snapshots__/useFillPaintStyle.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",

--- a/src/localStyles/__tests__/__snapshots__/useStrokePaintStyle.test.tsx.snap
+++ b/src/localStyles/__tests__/__snapshots__/useStrokePaintStyle.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "blendMode": "NORMAL",

--- a/src/localStyles/__tests__/__snapshots__/useTextStyle.test.tsx.snap
+++ b/src/localStyles/__tests__/__snapshots__/useTextStyle.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "_characters": "",

--- a/src/mixins/pageMixin.ts
+++ b/src/mixins/pageMixin.ts
@@ -1,0 +1,6 @@
+import { propsAssign } from '../helpers/propsAssign';
+import { PageProps } from '../components/page/Page';
+
+export const pageMixin = propsAssign<PageProps, PageProps>(['backgrounds'], {
+    backgrounds: []
+});

--- a/src/renderers/page.ts
+++ b/src/renderers/page.ts
@@ -1,6 +1,7 @@
 import { baseNodeMixin } from '../mixins/baseNodeMixin';
 import { saveStyleMixin } from '../mixins/saveStyleMixin';
 import { exportMixin } from '../mixins/exportMixin';
+import { pageMixin } from '../mixins/pageMixin';
 import { PageProps } from '../components/page/Page';
 
 export const page = (node: PageNode) => (props: PageProps) => {
@@ -9,6 +10,8 @@ export const page = (node: PageNode) => (props: PageProps) => {
     saveStyleMixin(page)(props);
     baseNodeMixin(page)(props);
     exportMixin(page)(props);
+
+    pageMixin(page)(props);
 
     return page;
 };

--- a/src/yoga/__tests__/__snapshots__/integration.test.tsx.snap
+++ b/src/yoga/__tests__/__snapshots__/integration.test.tsx.snap
@@ -10,6 +10,7 @@ ChildrenMixinStub {
       "type": "PAGE",
     },
     ExportMixinStub {
+      "backgrounds": Array [],
       "children": Array [
         ExportMixinStub {
           "backgrounds": Array [


### PR DESCRIPTION
This PR adds support for setting a background style on Pages.

```tsx
<Page backgrounds={[{ type: 'SOLID', color: { r: 1, g: 0, b: 0 } }]}>
  {/* ... */}
</Page>
```

I think it'd probably be best if I also implement the `style={{ backgroundColor }}` prop too... but let me know if this is the right approach 😄 