### PR TITLE
Support using style by styleId

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,4 @@ export { useFillPaintStyle } from './localStyles/useFillPaintStyle';
 export { useStrokePaintStyle } from './localStyles/useStrokePaintStyle';
 export { useTextStyle } from './localStyles/useTextStyle';
 export { useEffectStyle } from './localStyles/useEffectStyle';
+export { useStyleByKey } from './localStyles/useStyleByKey';

--- a/src/localStyles/__tests__/__snapshots__/useStyleByKey.test.tsx.snap
+++ b/src/localStyles/__tests__/__snapshots__/useStyleByKey.test.tsx.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useStyleByKey useTextStyle correctly applied 1`] = `
+ChildrenMixinStub {
+  "children": Array [
+    ExportMixinStub {
+      "children": Array [],
+      "id": "0:1",
+      "parent": [Circular],
+      "type": "PAGE",
+    },
+    ExportMixinStub {
+      "children": Array [
+        ExportMixinStub {
+          "blendMode": "NORMAL",
+          "constraints": Object {
+            "horizontal": "MIN",
+            "vertical": "MIN",
+          },
+          "cornerRadius": 0,
+          "cornerSmoothing": 0,
+          "effects": Array [],
+          "exportSettings": Array [],
+          "fillStyleId": "testStyleId",
+          "fills": Array [],
+          "id": "1:2",
+          "isMask": false,
+          "layoutAlign": "INHERIT",
+          "layoutGrow": 0,
+          "locked": false,
+          "opacity": 1,
+          "parent": [Circular],
+          "pluginData": Object {
+            "isReactFigmaNode": "true",
+            "reactStyle": "{\\"fillStyleId\\":\\"testStyleId\\"}",
+          },
+          "strokeAlign": "INSIDE",
+          "strokeCap": "NONE",
+          "strokeWeight": 0,
+          "strokes": Array [],
+          "type": "RECTANGLE",
+          "visible": true,
+        },
+        ExportMixinStub {
+          "_characters": "",
+          "_textAutoResize": "WIDTH_AND_HEIGHT",
+          "autoRename": false,
+          "blendMode": "NORMAL",
+          "constraints": Object {
+            "horizontal": "MIN",
+            "vertical": "MIN",
+          },
+          "effects": Array [],
+          "exportSettings": Array [],
+          "fills": Array [
+            Object {
+              "color": Object {
+                "b": 0,
+                "g": 0,
+                "r": 0,
+              },
+              "opacity": 1,
+              "type": "SOLID",
+            },
+          ],
+          "fontSize": 12,
+          "hyperlink": null,
+          "id": "1:3",
+          "isMask": false,
+          "layoutAlign": "INHERIT",
+          "layoutGrow": 0,
+          "letterSpacing": Object {
+            "unit": "PIXELS",
+            "value": 0,
+          },
+          "lineHeight": Object {
+            "unit": "AUTO",
+          },
+          "locked": false,
+          "opacity": 1,
+          "paragraphIndent": 0,
+          "paragraphSpacing": 0,
+          "parent": [Circular],
+          "pluginData": Object {
+            "isReactFigmaNode": "true",
+            "reactStyle": "{\\"textStyleId\\":\\"testStyleId\\"}",
+          },
+          "strokeAlign": "INSIDE",
+          "strokeCap": "NONE",
+          "strokeWeight": 0,
+          "strokes": Array [],
+          "textAlignHorizontal": "LEFT",
+          "textAlignVertical": "TOP",
+          "textCase": "ORIGINAL",
+          "textDecoration": "NONE",
+          "textStyleId": "testStyleId",
+          "type": "TEXT",
+          "visible": true,
+        },
+      ],
+      "exportSettings": Array [],
+      "id": "1:1",
+      "parent": [Circular],
+      "pluginData": Object {
+        "isReactFigmaNode": "true",
+        "reactStyle": "{}",
+      },
+      "type": "PAGE",
+    },
+  ],
+  "id": "0:0",
+  "type": "DOCUMENT",
+}
+`;

--- a/src/localStyles/__tests__/useStyleByKey.test.tsx
+++ b/src/localStyles/__tests__/useStyleByKey.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { createFigma } from 'figma-api-stub';
+import { render } from '../../renderer';
+import { wait } from '../../helpers/wait';
+import { Text } from '../../components/text/Text';
+import { View } from '../../components/view/View';
+import { Page } from '../../components/page/Page';
+import { removeNodeBatchId } from '../../helpers/removeNodeBatchId';
+import { removeTempId } from '../../helpers/removeTempId';
+
+const removeMeta = node => {
+    return removeNodeBatchId(removeTempId(node));
+};
+
+jest.mock('nanoid');
+import { nanoid } from 'nanoid';
+import { useStyleByKey } from '../useStyleByKey';
+
+describe('useStyleByKey', () => {
+    beforeEach(() => {
+        // @ts-ignore
+        global.figma = createFigma({
+            simulateErrors: true
+        });
+        // @ts-ignore
+        global.figma.importStyleByKeyAsync = jest.fn().mockReturnValue({ id: 'testStyleId' });
+    });
+
+    it('useTextStyle correctly applied', async () => {
+        // @ts-ignore
+        nanoid.mockReturnValue('test');
+        const ViewComponent = () => {
+            const fillStyle = useStyleByKey('testStyleId');
+            return (
+                <View
+                    style={{
+                        fillStyleId: fillStyle && fillStyle.id
+                    }}
+                />
+            );
+        };
+        const TextComponent = () => {
+            const textStyle = useStyleByKey('testStyleId');
+            return (
+                <Text
+                    style={{
+                        textStyleId: textStyle && textStyle.id
+                    }}
+                />
+            );
+        };
+        await render(
+            <Page>
+                <ViewComponent />
+                <TextComponent />
+            </Page>
+        );
+        await wait();
+        // @ts-ignore
+        expect(removeMeta(figma.root)).toMatchSnapshot();
+    });
+});

--- a/src/localStyles/useStyleByKey.ts
+++ b/src/localStyles/useStyleByKey.ts
@@ -1,0 +1,15 @@
+import { api } from '../rpc';
+import * as React from 'react';
+import { CommonStyle } from '../types';
+
+export const useStyleByKey = (styleKey: string): BaseStyle => {
+    const [style, setStyle] = React.useState<BaseStyle>(null);
+
+    React.useEffect(() => {
+        if (styleKey) {
+            api.importStyleByKeyAsync(styleKey).then(setStyle);
+        }
+    }, [styleKey]);
+
+    return style;
+};

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -210,6 +210,10 @@ export const api = createPluginAPI(
             }
         },
 
+        async importStyleByKeyAsync(key: string): Promise<BaseStyle> {
+            return figma.importStyleByKeyAsync(key);
+        },
+
         createOrUpdatePaintStyle(properties: {
             paints: ReadonlyArray<Paint> | symbol | void;
             params: CommonStyleProps;

--- a/src/styleTransformers/transformGeometryStyleProperties.ts
+++ b/src/styleTransformers/transformGeometryStyleProperties.ts
@@ -9,6 +9,7 @@ export type GeometryStyleProperties = {
     backgroundColor: string;
     backgroundImage: string | { uri: string } | { default: string };
     backgroundSize: ResizeMode;
+    fillStyleId?: string;
 };
 
 const backgroundSizeToScaleMode = {
@@ -22,7 +23,7 @@ const backgroundSizeToScaleMode = {
 
 export const transformGeometryStyleProperties = (
     property: 'fills' | 'backgrounds',
-    style?: Partial<LayoutStyleProperties & GeometryStyleProperties & { fillStyleId?: string; strokeStyleId?: string }>,
+    style?: Partial<LayoutStyleProperties & GeometryStyleProperties & { strokeStyleId?: string }>,
     imageHash?: string
 ): GeometryProps => {
     if (!style) {


### PR DESCRIPTION
# Context
PR exposes `useStyleByKey` hook which allows one to pass in specific `textStyleId`, `fillStyleId`, etc.

# Test
Notice in the video below, the background of the first rectangle is red but there isn't a local style for red. That's because I grabbed it from another file's style id :) Also the font type is "Tool Name" but we don't have that in local styles either because it's from another file.

https://user-images.githubusercontent.com/6846913/156708255-73ad19a9-deca-4f1c-bd61-31aee0b19581.mov

Also wrote a test for the hook and saw the snapshot was good.