### PR TITLE
Fix PrimerDemo link

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -11,7 +11,7 @@ title: Ecosystem
 * [Interactive](https://github.com/react-figma/react-figma/tree/master/examples/interactive)
 * [Data fetching](https://github.com/react-figma/react-figma/tree/master/examples/fetching)
 * [💅 styled-components](https://github.com/react-figma/react-figma/tree/master/examples/styled-components)
-* [PrimerDemo](https://github.com/react-figma/react-figma/PrimerDemo) - Example of multiplatform UI-kit
+* [PrimerDemo](https://github.com/react-figma/PrimerDemo) - Example of multiplatform UI-kit
 * [Component Variants](https://github.com/react-figma/react-figma/tree/master/examples/component-variants)
 * [MDX](https://github.com/react-figma/react-figma/tree/master/examples/mdx)
 


### PR DESCRIPTION
This fixes the link to PrimerDemo as it is its own repo, and not within the react-figma repo.