### PR TITLE
Fix typo

### DIFF
--- a/docs/api/Frame.md
+++ b/docs/api/Frame.md
@@ -83,5 +83,5 @@ List of presets:
 ```jsx
 <Frame name="List">
   <Text>Hello world!</Text>
-</Component>
+</Frame>
 ```

--- a/docs/api/Group.md
+++ b/docs/api/Group.md
@@ -24,5 +24,5 @@ Also, most of the [FrameNode](https://www.figma.com/plugin-docs/api/FrameNode/) 
 ```jsx
 <Group name="Comp">
   <Text>Hello world!</Text>
-</Component>
+</Group>
 ```


### PR DESCRIPTION
Fix typo:

docs/api/Frame.md
corrected closing tag in jsx example code
</ Component> --> </ Frame>

docs/api/Group.md
corrected closing tag in jsx example code
</ Component> --> </ Group>